### PR TITLE
Refactor crawl command and improve CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,20 @@
 Thank you for considering contributing to Tapio Assistant! This document provides guidelines and instructions for contributing to this project.
 
 ## Table of Contents
-- [Technical Architecture](#technical-architecture)
-- [Development Environment Setup](#development-environment-setup)
-- [Package Management](#package-management)
-- [Code Quality](#code-quality)
-- [Testing Guidelines](#testing-guidelines)
-- [Project Structure](#project-structure)
-- [Ollama for LLM Inference](#ollama-for-llm-inference)
-- [Pull Request Process](#pull-request-process)
+- [Contributing to Tapio Assistant](#contributing-to-tapio-assistant)
+  - [Table of Contents](#table-of-contents)
+  - [Technical Architecture](#technical-architecture)
+  - [Development Environment Setup](#development-environment-setup)
+  - [Package Management](#package-management)
+  - [Code Quality](#code-quality)
+    - [Ruff](#ruff)
+  - [Testing Guidelines](#testing-guidelines)
+    - [Running Tests](#running-tests)
+    - [Code Coverage](#code-coverage)
+  - [Project Structure](#project-structure)
+  - [Configuration System](#configuration-system)
+  - [Ollama for LLM Inference](#ollama-for-llm-inference)
+  - [Pull Request Process](#pull-request-process)
 
 ## Technical Architecture
 
@@ -110,20 +116,15 @@ We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Please e
 You can run the linter with the following command:
 
 ```bash
-uv run ruff .
+uv run ruff check .
 ```
 
 You can also run the linter with the `--fix` option to automatically fix some issues:
 
 ```bash
-uv run ruff . --fix
+uv run ruff check . --fix
 ```
 
-Or check for issues without fixing them:
-
-```bash
-uv run ruff . --check
-```
 
 ## Testing Guidelines
 

--- a/tapio/cli.py
+++ b/tapio/cli.py
@@ -47,12 +47,6 @@ def crawl(
         "-D",
         help="Domains to restrict crawling to (defaults to site's domain)",
     ),
-    output_dir: str = typer.Option(
-        DEFAULT_DIRS["CRAWLED_DIR"],
-        "--output-dir",
-        "-o",
-        help="Directory to save crawled HTML files",
-    ),
     verbose: bool = typer.Option(
         False,
         "--verbose",
@@ -69,7 +63,7 @@ def crawl(
     The crawler is interruptible - press Ctrl+C to stop and save current progress.
 
     Example:
-        $ python -m tapio.cli crawl migri -d 2 -o migri_content
+        $ python -m tapio.cli crawl migri -d 2
     """
     # Set log level based on verbose flag
     if verbose:
@@ -102,7 +96,7 @@ def crawl(
         allowed_domains = [parsed_url.netloc]
 
     typer.echo(f"🕸️ Starting web crawler for {site} ({url}) with depth {depth}")
-    typer.echo(f"💾 Saving HTML content to: {output_dir}")
+    typer.echo(f"💾 Saving HTML content to: {DEFAULT_DIRS['CRAWLED_DIR']}")
 
     try:
         # Initialize crawler runner
@@ -115,17 +109,17 @@ def crawl(
             start_urls=[str(url)],  # Convert HttpUrl to string
             depth=depth,
             allowed_domains=allowed_domains,
-            output_dir=output_dir,
+            output_dir=DEFAULT_DIRS["CRAWLED_DIR"],
         )
 
         # Output information
         typer.echo(f"✅ Crawling completed! Processed {len(results)} pages.")
-        typer.echo(f"💾 Content saved as HTML files in {output_dir}")
+        typer.echo(f"💾 Content saved as HTML files in {DEFAULT_DIRS['CRAWLED_DIR']}")
 
     except KeyboardInterrupt:
         typer.echo("\n🛑 Crawling interrupted by user")
         typer.echo("✅ Partial results have been saved")
-        typer.echo(f"💾 Crawled content saved to {output_dir}")
+        typer.echo(f"💾 Crawled content saved to {DEFAULT_DIRS['CRAWLED_DIR']}")
     except Exception as e:
         typer.echo(f"❌ Error during crawling: {str(e)}", err=True)
         raise typer.Exit(code=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,8 +58,6 @@ class TestCli:
                 "migri",
                 "--depth",
                 "2",
-                "--output-dir",
-                "test_output",
             ],
         )
 
@@ -80,7 +78,7 @@ class TestCli:
             start_urls=["https://example.com"],  # URL from site config
             depth=2,
             allowed_domains=["example.com"],  # Domain extracted from URL
-            output_dir="test_output",
+            output_dir=DEFAULT_DIRS["CRAWLED_DIR"],
         )
 
         # Check expected output in stdout


### PR DESCRIPTION
Refactor the crawl command to use a default output directory and update related tests. Enhance the structure and clarity of the CONTRIBUTING.md file, particularly regarding linting commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved the contributing guide with a clearer structure, expanded sections, and updated linter command examples.

- **Bug Fixes**
  - The crawl command now always saves output to the default directory, removing the option to specify a custom output directory.

- **Tests**
  - Updated tests to align with the removal of the custom output directory option in the crawl command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->