### PR TITLE
Remove site_name references in favor of site attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ Each site configuration includes:
 ```yaml
 sites:
   migri:                                    # Site key used with --site
-    site_name: "migri"                      # Name for output directories and logs
     base_url: "https://migri.fi"            # Base URL for converting relative links (optional, default: "https://example.com")
                                             # The base directory is automatically derived from this URL (e.g., "migri.fi")
     title_selector: "//title"               # XPath selector for page title

--- a/tapio/cli.py
+++ b/tapio/cli.py
@@ -198,10 +198,9 @@ def parse(
         results = parser.parse_all()
 
         # Output information
-        site_name = parser.config.site_name if hasattr(parser, "config") else parser.site_name
         typer.echo(f"✅ Parsing completed! Processed {len(results)} files.")
         typer.echo(f"📝 Content saved as Markdown files in {DEFAULT_DIRS['PARSED_DIR']}")
-        typer.echo(f"📝 Index created at {DEFAULT_DIRS['PARSED_DIR']}/{site_name}/index.md")
+        typer.echo(f"📝 Index created at {DEFAULT_DIRS['PARSED_DIR']}/{parser.site}/index.md")
 
     except Exception as e:
         typer.echo(f"❌ Error during parsing: {str(e)}", err=True)
@@ -316,7 +315,6 @@ def info(
         try:
             config = config_manager.get_site_config(show_site_config)
             typer.echo(f"Configuration for site: {show_site_config}")
-            typer.echo(f"  Site name: {config.site_name}")
             typer.echo(f"  Base URL: {config.base_url}")
             typer.echo(f"  Base directory: {config.base_dir}")
             typer.echo(f"  Description: {config.description}")
@@ -438,7 +436,6 @@ def list_sites(
                     # Get detailed configuration for the site
                     site_config = config_manager.get_site_config(site_name)
                     typer.echo(f"\n📄 {site_name}:")
-                    typer.echo(f"  Site name: {site_config.site_name}")
                     typer.echo(f"  Description: {site_config.description or 'No description'}")
                     typer.echo(f"  Title selector: {site_config.title_selector}")
                     typer.echo("  Content selectors:")

--- a/tapio/config/config_models.py
+++ b/tapio/config/config_models.py
@@ -33,7 +33,7 @@ class SiteParserConfig(BaseModel):
     used to identify important page elements and conversion settings.
     """
 
-    site_name: str
+    # site_name: str
     base_url: HttpUrl
     # Note: In Pydantic v2, default HttpUrl values need to be provided using model_config
     # or Field validators; using literal default values can cause type errors

--- a/tapio/parser/parser.py
+++ b/tapio/parser/parser.py
@@ -94,8 +94,8 @@ class Parser:
         self.current_base_url: str | None = None  # Will store the base URL of the current document
 
         self.input_dir = input_dir
-        self.output_dir = os.path.join(output_dir, self.config.site_name or "default")
-        self.site_name = self.config.site_name
+        self.output_dir = os.path.join(output_dir, self.site or "default")
+
         self.setup_logging()
 
         # Load URL mappings if available
@@ -105,7 +105,7 @@ class Parser:
         # Create output directory if it doesn't exist
         os.makedirs(self.output_dir, exist_ok=True)
 
-        logging.info(f"Initialized Parser for {self.config.site_name}")
+        logging.info(f"Initialized Parser for {self.site}")
 
     def setup_logging(self) -> None:
         """Set up logging configuration"""
@@ -735,7 +735,7 @@ class Parser:
         index_path = os.path.join(self.output_dir, "index.md")
 
         with open(index_path, "w", encoding="utf-8") as f:
-            f.write(f"# {self.site_name or 'Site'} Parsed Content Index\n\n")
+            f.write(f"# {self.site or 'Site'} Parsed Content Index\n\n")
             f.write(f"Total pages parsed: {len(results)}\n\n")
             f.write("| Title | Source File | Output File |\n")
             f.write("|-------|-------------|-------------|\n")

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -157,7 +157,6 @@ class TestConfigManager:
             config_manager = ConfigManager()
             site_config = config_manager.get_site_config("test_site")
             assert isinstance(site_config, SiteParserConfig)
-            assert site_config.site_name == "test"
             assert str(site_config.base_url) == "https://example.com/"
             assert "//main" in site_config.content_selectors
 

--- a/tests/config/test_config_models.py
+++ b/tests/config/test_config_models.py
@@ -118,11 +118,9 @@ class TestSiteParserConfig:
     def test_default_values(self):
         """Test default values for SiteParserConfig."""
         config = SiteParserConfig(
-            site_name="test",
             base_url=HttpUrl("https://example.com"),
             content_selectors=['//div[@id="main"]'],
         )
-        assert config.site_name == "test"
         assert str(config.base_url) == "https://example.com/"
         assert config.title_selector == "//title"
         assert config.fallback_to_body is True
@@ -219,7 +217,6 @@ class TestParserConfigRegistry:
         config_data = {
             "sites": {
                 "test": {
-                    "site_name": "test",
                     "base_url": "https://example.com",
                     "content_selectors": ["//div"],
                 },
@@ -227,7 +224,6 @@ class TestParserConfigRegistry:
         }
         registry = ParserConfigRegistry.model_validate(config_data)
         assert "test" in registry.sites
-        assert registry.sites["test"].site_name == "test"
         assert str(registry.sites["test"].base_url) == "https://example.com/"
 
         # Invalid config (missing required fields)

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -81,7 +81,6 @@ class TestParser(unittest.TestCase):
         self.test_config = {
             "sites": {
                 "example": {
-                    "site_name": "example",
                     "base_url": f"https://{self.domain}",
                     "base_dir": self.domain,
                     "title_selector": "//title",
@@ -95,7 +94,6 @@ class TestParser(unittest.TestCase):
                     "markdown_config": {"ignore_links": False, "body_width": 0},
                 },
                 "no_fallback": {
-                    "site_name": "no_fallback",
                     "base_url": f"https://{self.domain}",
                     "base_dir": self.domain,
                     "title_selector": "//h1",
@@ -130,10 +128,8 @@ class TestParser(unittest.TestCase):
         self.assertEqual(self.parser.site, "example")
         self.assertEqual(self.parser.input_dir, self.input_dir)
         self.assertEqual(self.parser.output_dir, os.path.join(self.output_dir, "example"))
-        self.assertEqual(self.parser.site_name, "example")
 
         # Test config loaded correctly
-        self.assertEqual(self.parser.config.site_name, "example")
         self.assertEqual(self.parser.config.title_selector, "//title")
         self.assertEqual(len(self.parser.config.content_selectors), 3)
         self.assertTrue(self.parser.config.fallback_to_body)
@@ -263,7 +259,6 @@ class TestParser(unittest.TestCase):
         config = Parser.get_site_config("example", self.config_path)
         self.assertIsNotNone(config)
         if config:  # Check if config is not None before accessing attributes
-            self.assertEqual(config.site_name, "example")
             self.assertEqual(config.description, "Example Website for Testing")
 
         # Test getting non-existent site config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -525,7 +525,6 @@ class TestCli:
 
         # Mock site config
         mock_site_config = MagicMock()
-        mock_site_config.site_name = "migri"
         mock_site_config.description = "Finnish Immigration Service"
         mock_site_config.title_selector = "h1"
         mock_site_config.content_selectors = ["main", "article"]
@@ -548,7 +547,6 @@ class TestCli:
 
         # Check expected output in stdout
         assert "Available Site Configurations:" in result.stdout
-        assert "Site name: migri" in result.stdout
         assert "Description: Finnish Immigration Service" in result.stdout
         assert "Title selector: h1" in result.stdout
         assert "Content selectors:" in result.stdout


### PR DESCRIPTION
Eliminate the use of `site_name` in the Parser and related tests, replacing it with the `site` attribute for consistency and clarity. This change streamlines site configuration handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified site configuration and CLI output by removing the explicit use of the `site_name` field across the application.
  - Unified references to use the site identifier consistently throughout the interface and internal logic.

- **Bug Fixes**
  - Updated tests and documentation to reflect the removal of the `site_name` field, ensuring consistency and preventing potential errors.

- **Documentation**
  - Updated example configuration in the documentation to remove the `site_name` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->