### PR TITLE
Refactor site configuration structure to introduce parser_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,38 +97,42 @@ Site configurations define how to crawl and parse specific websites. They're sto
 sites:
   migri:
     base_url: "https://migri.fi"                # Used for crawling and converting relative links
-    title_selector: "//title"                   # XPath for page titles
-    content_selectors:                          # Priority-ordered content extraction
-      - '//div[@id="main-content"]'
-      - "//main"
-      - "//article"
-      - '//div[@class="content"]'
-    fallback_to_body: true                      # Use <body> if selectors fail
     description: "Finnish Immigration Service website"
-    markdown_config:                            # HTML-to-Markdown options
-      ignore_links: false
-      body_width: 0                             # No text wrapping
-      protect_links: true
-      unicode_snob: true
-      ignore_images: false
-      ignore_tables: false
-    crawler_config:                             # Crawling behavior
-      delay_between_requests: 1.0               # Seconds between requests
-      max_concurrent: 3                         # Concurrent request limit
+    crawler_config:                            # Crawling behavior
+      delay_between_requests: 1.0              # Seconds between requests
+      max_concurrent: 3                        # Concurrent request limit
+    parser_config:                              # Parser-specific configuration
+      title_selector: "//title"                # XPath for page titles
+      content_selectors:                       # Priority-ordered content extraction
+        - '//div[@id="main-content"]'
+        - "//main"
+        - "//article"
+        - '//div[@class="content"]'
+      fallback_to_body: true                   # Use <body> if selectors fail
+      markdown_config:                         # HTML-to-Markdown options
+        ignore_links: false
+        body_width: 0                          # No text wrapping
+        protect_links: true
+        unicode_snob: true
+        ignore_images: false
+        ignore_tables: false
 ```
 
 ### Required vs Optional Fields
 
 **Required:**
 - `base_url` - Base URL for the site (used for crawling and link resolution)
-- `content_selectors` - At least one XPath selector for content extraction
 
 **Optional (with defaults):**
-- `title_selector` - Page title XPath (default: "//title")
-- `fallback_to_body` - Use full body content if selectors fail (default: true)
 - `description` - Human-readable description
-- `markdown_config` - HTML conversion settings (uses defaults if omitted)
+- `parser_config` - Parser-specific settings (uses defaults if omitted)
+  - `title_selector` - Page title XPath (default: "//title")
+  - `content_selectors` - XPath selectors for content extraction (default: ["//main", "//article", "//body"])
+  - `fallback_to_body` - Use full body content if selectors fail (default: true)
+  - `markdown_config` - HTML conversion settings (uses defaults if omitted)
 - `crawler_config` - Crawling behavior settings (uses defaults if omitted)
+  - `delay_between_requests` - Delay between requests in seconds (default: 1.0)
+  - `max_concurrent` - Maximum concurrent requests (default: 5)
 
 ### Adding New Sites
 
@@ -140,9 +144,10 @@ sites:
 sites:
   my_site:
     base_url: "https://example.com"
-    content_selectors:
-      - '//div[@class="main-content"]'
     description: "Example site configuration"
+    parser_config:
+      content_selectors:
+        - '//div[@class="main-content"]'
 ```
 
 4. Use with commands:

--- a/tapio/cli.py
+++ b/tapio/cli.py
@@ -412,9 +412,9 @@ def info(
             typer.echo(f"  Base directory: {config.base_dir}")
             typer.echo(f"  Description: {config.description}")
             typer.echo("  Content selectors:")
-            for selector in config.content_selectors:
+            for selector in config.parser_config.content_selectors:
                 typer.echo(f"    - {selector}")
-            typer.echo(f"  Fallback to body: {config.fallback_to_body}")
+            typer.echo(f"  Fallback to body: {config.parser_config.fallback_to_body}")
         except ValueError:
             typer.echo(f"Error: Site configuration '{show_site_config}' not found")
         return
@@ -529,11 +529,11 @@ def list_sites(
                     site_config = config_manager.get_site_config(site_name)
                     typer.echo(f"\n📄 {site_name}:")
                     typer.echo(f"  Description: {site_config.description or 'No description'}")
-                    typer.echo(f"  Title selector: {site_config.title_selector}")
+                    typer.echo(f"  Title selector: {site_config.parser_config.title_selector}")
                     typer.echo("  Content selectors:")
-                    for selector in site_config.content_selectors:
+                    for selector in site_config.parser_config.content_selectors:
                         typer.echo(f"    - {selector}")
-                    typer.echo(f"  Fallback to body: {site_config.fallback_to_body}")
+                    typer.echo(f"  Fallback to body: {site_config.parser_config.fallback_to_body}")
                     typer.echo("  Crawler configuration:")
                     typer.echo(f"    - Delay between requests: {site_config.crawler_config.delay_between_requests}s")
                     typer.echo(f"    - Max concurrent requests: {site_config.crawler_config.max_concurrent}")

--- a/tapio/config/__init__.py
+++ b/tapio/config/__init__.py
@@ -8,12 +8,12 @@ from tapio.config.config_manager import ConfigManager
 from tapio.config.config_models import (
     HtmlToMarkdownConfig,
     ParserConfigRegistry,
-    SiteParserConfig,
+    SiteConfig,
 )
 
 __all__ = [
     "ConfigManager",
     "HtmlToMarkdownConfig",
     "ParserConfigRegistry",
-    "SiteParserConfig",
+    "SiteConfig",
 ]

--- a/tapio/config/config_manager.py
+++ b/tapio/config/config_manager.py
@@ -9,7 +9,7 @@ import os
 
 import yaml
 
-from tapio.config.config_models import ParserConfigRegistry, SiteParserConfig
+from tapio.config.config_models import ParserConfigRegistry, SiteConfig
 
 
 class ConfigManager:
@@ -66,7 +66,7 @@ class ConfigManager:
             self.logger.error(f"Invalid configuration: {e}")
             raise
 
-    def get_site_config(self, site: str) -> SiteParserConfig:
+    def get_site_config(self, site: str) -> SiteConfig:
         """
         Get configuration for a specific site.
 

--- a/tapio/config/site_configs.yaml
+++ b/tapio/config/site_configs.yaml
@@ -2,21 +2,22 @@
 sites:
   migri:
     base_url: "https://migri.fi"
-    title_selector: "//title"
-    content_selectors:
-      - '//div[@id="main-content"]'
-      - "//main"
-      - "//article"
-      - '//div[@class="content"]'
-    fallback_to_body: true
     description: "Finnish Immigration Service website"
-    markdown_config:
-      ignore_links: false
-      body_width: 0
-      protect_links: true
-      unicode_snob: true
-      ignore_images: false
-      ignore_tables: false
+    parser_config:
+      title_selector: "//title"
+      content_selectors:
+        - '//div[@id="main-content"]'
+        - "//main"
+        - "//article"
+        - '//div[@class="content"]'
+      fallback_to_body: true
+      markdown_config:
+        ignore_links: false
+        body_width: 0
+        protect_links: true
+        unicode_snob: true
+        ignore_images: false
+        ignore_tables: false
     crawler_config:
       delay_between_requests: 1.0
       max_concurrent: 3
@@ -24,14 +25,15 @@ sites:
   # Example configuration for TE Services website
   te_palvelut:
     base_url: "https://toimistot.te-palvelut.fi"
-    title_selector: "//title"
-    content_selectors:
-      - '//div[@class="content-main"]'
-      - '//main[@role="main"]'
-    fallback_to_body: true
     description: "TE Services (Work and Economic Development) website"
-    markdown_config:
-      ignore_tables: false
+    parser_config:
+      title_selector: "//title"
+      content_selectors:
+        - '//div[@class="content-main"]'
+        - '//main[@role="main"]'
+      fallback_to_body: true
+      markdown_config:
+        ignore_tables: false
     crawler_config:
       delay_between_requests: 1.5
       max_concurrent: 3
@@ -39,13 +41,14 @@ sites:
   # Example configuration for Kela website
   kela:
     base_url: "https://www.kela.fi"
-    title_selector: "//h1 | //title"
-    content_selectors:
-      - '//div[@id="content-root"]'
-    fallback_to_body: true
     description: "Kela (Social Insurance Institution of Finland) website"
-    markdown_config:
-      ignore_images: true
+    parser_config:
+      title_selector: "//h1 | //title"
+      content_selectors:
+        - '//div[@id="content-root"]'
+      fallback_to_body: true
+      markdown_config:
+        ignore_images: true
     crawler_config:
       delay_between_requests: 1.2
       max_concurrent: 4
@@ -53,13 +56,14 @@ sites:
   # Example configuration for Vero website
   vero:
     base_url: "https://www.vero.fi/en/"
-    title_selector: "//h1 | //title"
-    content_selectors:
-      - '//main[@id="content-container"]'
-    fallback_to_body: true
     description: "Vero (Guidance about taxation in Finland) website"
-    markdown_config:
-      ignore_images: true
+    parser_config:
+      title_selector: "//h1 | //title"
+      content_selectors:
+        - '//main[@id="content-container"]'
+      fallback_to_body: true
+      markdown_config:
+        ignore_images: true
     crawler_config:
       delay_between_requests: 2.0
       max_concurrent: 2

--- a/tapio/parser/__init__.py
+++ b/tapio/parser/__init__.py
@@ -8,7 +8,7 @@ from HTML files saved by the crawler module.
 from tapio.config.config_models import (
     HtmlToMarkdownConfig,
     ParserConfigRegistry,
-    SiteParserConfig,
+    SiteConfig,
 )
 from tapio.parser.parser import Parser
 
@@ -16,5 +16,5 @@ __all__ = [
     "HtmlToMarkdownConfig",
     "Parser",
     "ParserConfigRegistry",
-    "SiteParserConfig",
+    "SiteConfig",
 ]

--- a/tapio/parser/parser.py
+++ b/tapio/parser/parser.py
@@ -17,7 +17,7 @@ import yaml
 from lxml import html
 
 from tapio.config import ConfigManager
-from tapio.config.config_models import SiteParserConfig
+from tapio.config.config_models import SiteConfig
 from tapio.config.settings import DEFAULT_DIRS
 
 
@@ -225,11 +225,11 @@ class Parser:
             tree = html.fromstring(html_content)
 
             # Extract the title using the configured selector
-            title_elements = tree.xpath(self.config.title_selector)
+            title_elements = tree.xpath(self.config.parser_config.title_selector)
             title = title_elements[0].text if title_elements else "Untitled"
 
             # Find content using the configured selectors
-            content_section = self.config.get_content_selector(tree)
+            content_section = self.config.parser_config.get_content_selector(tree)
 
             # Prepare HTML content for conversion
             if content_section is not None:
@@ -240,7 +240,7 @@ class Parser:
                     pretty_print=True,
                 )
                 self.logger.info("Successfully extracted content section")
-            elif self.config.fallback_to_body:
+            elif self.config.parser_config.fallback_to_body:
                 # If no content section found and fallback is enabled, use the body
                 body = tree.xpath("//body")
                 content_html = html.tostring(body[0], encoding="unicode", pretty_print=True) if body else html_content
@@ -347,7 +347,7 @@ class Parser:
             Markdown formatted text
         """
         # Configure html2text with site-specific settings
-        config = self.config.markdown_config
+        config = self.config.parser_config.markdown_config
         text_maker = html2text.HTML2Text()
         text_maker.ignore_links = config.ignore_links
         text_maker.body_width = config.body_width
@@ -770,7 +770,7 @@ class Parser:
         cls,
         site: str,
         config_path: str | None = None,
-    ) -> SiteParserConfig | None:
+    ) -> SiteConfig | None:
         """
         Get detailed information about a specific site configuration.
 

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -7,7 +7,7 @@ import yaml
 from pydantic import ValidationError
 
 from tapio.config import ConfigManager
-from tapio.config.config_models import SiteParserConfig
+from tapio.config.config_models import SiteConfig
 
 
 class TestConfigManager:
@@ -19,10 +19,10 @@ class TestConfigManager:
         return """
             sites:
               test_site:
-                site_name: "test"
                 base_url: "https://example.com"
-                content_selectors:
-                  - "//main"
+                parser_config:
+                  content_selectors:
+                    - "//main"
         """
 
     @pytest.fixture
@@ -31,20 +31,23 @@ class TestConfigManager:
         return """
             sites:
               site1:
-                site_name: "Site 1"
                 base_url: "https://site1.com"
-                content_selectors:
-                  - "//main"
+                description: "Site 1"
+                parser_config:
+                  content_selectors:
+                    - "//main"
               site2:
-                site_name: "Site 2"
                 base_url: "https://site2.com"
-                content_selectors:
-                  - "//main"
+                description: "Site 2"
+                parser_config:
+                  content_selectors:
+                    - "//main"
               site3:
-                site_name: "Site 3"
                 base_url: "https://site3.com"
-                content_selectors:
-                  - "//main"
+                description: "Site 3"
+                parser_config:
+                  content_selectors:
+                    - "//main"
         """
 
     @pytest.fixture
@@ -53,22 +56,22 @@ class TestConfigManager:
         return """
             sites:
               site1:
-                site_name: "Site 1"
                 base_url: "https://site1.com"
-                content_selectors:
-                  - "//main"
                 description: "First site description"
+                parser_config:
+                  content_selectors:
+                    - "//main"
               site2:
-                site_name: "Site 2"
                 base_url: "https://site2.com"
-                content_selectors:
-                  - "//main"
                 description: "Second site description"
+                parser_config:
+                  content_selectors:
+                    - "//main"
               site3:
-                site_name: "Site 3"
                 base_url: "https://site3.com"
-                content_selectors:
-                  - "//main"
+                parser_config:
+                  content_selectors:
+                    - "//main"
         """
 
     @pytest.fixture
@@ -77,10 +80,10 @@ class TestConfigManager:
         return """
             sites:
               invalid_url_site:
-                site_name: "invalid"
                 base_url: "invalid-url"
-                content_selectors:
-                  - "//main"
+                parser_config:
+                  content_selectors:
+                    - "//main"
         """
 
     def test_init_default_path(self, basic_config_yaml):
@@ -156,9 +159,9 @@ class TestConfigManager:
         ):
             config_manager = ConfigManager()
             site_config = config_manager.get_site_config("test_site")
-            assert isinstance(site_config, SiteParserConfig)
+            assert isinstance(site_config, SiteConfig)
             assert str(site_config.base_url) == "https://example.com/"
-            assert "//main" in site_config.content_selectors
+            assert "//main" in site_config.parser_config.content_selectors
 
     def test_get_nonexistent_site_config(self, basic_config_yaml):
         """Test retrieving a non-existent site configuration."""

--- a/tests/config/test_config_models.py
+++ b/tests/config/test_config_models.py
@@ -3,7 +3,13 @@
 import pytest
 from pydantic import HttpUrl, ValidationError
 
-from tapio.config.config_models import CrawlerConfig, HtmlToMarkdownConfig, ParserConfigRegistry, SiteParserConfig
+from tapio.config.config_models import (
+    CrawlerConfig,
+    HtmlToMarkdownConfig,
+    ParserConfig,
+    ParserConfigRegistry,
+    SiteConfig,
+)
 
 
 class TestCrawlerConfig:
@@ -52,99 +58,78 @@ class TestCrawlerConfig:
             CrawlerConfig(max_concurrent=51)
 
 
-class TestSiteParserConfigBaseDir:
-    """Tests for the SiteParserConfig base_dir property."""
+class TestParserConfig:
+    """Test the ParserConfig model."""
 
-    def test_normal_url(self):
-        """Test base_dir with normal URL."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://example.com"),
-            content_selectors=['//div[@id="main"]'],
+    def test_default_values(self):
+        """Test default values for ParserConfig."""
+        config = ParserConfig()
+        assert config.title_selector == "//title"
+        assert config.content_selectors == ["//main", "//article", "//body"]
+        assert config.fallback_to_body is True
+        assert isinstance(config.markdown_config, HtmlToMarkdownConfig)
+
+    def test_custom_values(self):
+        """Test ParserConfig with custom values."""
+        config = ParserConfig(
+            title_selector="//h1",
+            content_selectors=['//div[@id="main"]', "//article"],
+            fallback_to_body=False,
         )
-        assert config.base_dir == "example.com"
+        assert config.title_selector == "//h1"
+        assert config.content_selectors == ['//div[@id="main"]', "//article"]
+        assert config.fallback_to_body is False
 
-    def test_url_with_subdomain(self):
-        """Test base_dir with URL containing subdomain."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://docs.example.com"),
-            content_selectors=['//div[@id="main"]'],
+    def test_get_content_selector(self):
+        """Test the get_content_selector method."""
+        from lxml import html as lxml_html
+
+        # Create a test config
+        config = ParserConfig(
+            content_selectors=['//div[@id="main"]', '//div[@class="content"]', "//article"],
         )
-        assert config.base_dir == "docs.example.com"
 
-    def test_url_with_port(self):
-        """Test base_dir with URL containing port number."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://example.com:8080"),
-            content_selectors=['//div[@id="main"]'],
-        )
-        assert config.base_dir == "example.com"  # should exclude port
+        # Create a test HTML tree
+        html_content = """
+        <html>
+            <body>
+                <div class="content">Content here</div>
+                <article>Article content</article>
+            </body>
+        </html>
+        """
+        tree = lxml_html.fromstring(html_content)
 
-    def test_url_with_path(self):
-        """Test base_dir with URL containing path."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://example.com/path/to/page"),
-            content_selectors=['//div[@id="main"]'],
-        )
-        assert config.base_dir == "example.com"  # should exclude path
+        # Test first selector not found, second matches
+        element = config.get_content_selector(tree)
+        assert element is not None
+        assert element.text == "Content here"
 
-    def test_url_with_query_params(self):
-        """Test base_dir with URL containing query parameters."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://example.com?param=value"),
-            content_selectors=['//div[@id="main"]'],
-        )
-        assert config.base_dir == "example.com"  # should exclude query params
+        # Test when first selector matches
+        html_content = """
+        <html>
+            <body>
+                <div id="main">Main content</div>
+                <div class="content">Secondary content</div>
+            </body>
+        </html>
+        """
+        tree = lxml_html.fromstring(html_content)
+        element = config.get_content_selector(tree)
+        assert element is not None
+        assert element.text == "Main content"
 
-    def test_url_with_fragments(self):
-        """Test base_dir with URL containing fragments."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://example.com#section"),
-            content_selectors=['//div[@id="main"]'],
-        )
-        assert config.base_dir == "example.com"  # should exclude fragments
-
-    def test_localhost_url(self):
-        """Test base_dir with localhost URL."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("http://localhost:3000"),
-            content_selectors=['//div[@id="main"]'],
-        )
-        assert config.base_dir == "localhost"  # should exclude port
-
-    def test_ip_address_url(self):
-        """Test base_dir with IP address URL."""
-        config = SiteParserConfig(
-            base_url=HttpUrl("http://127.0.0.1:8080"),
-            content_selectors=['//div[@id="main"]'],
-        )
-        assert config.base_dir == "127.0.0.1"  # should exclude port
-
-    def test_empty_base_url(self):
-        """Test base_dir with empty base_url."""
-        # Now validation happens at initialization time with Pydantic HttpUrl
-        with pytest.raises(ValidationError, match=r"Input should be a valid URL"):
-            _ = SiteParserConfig(
-                base_url=HttpUrl(""),  # Empty string
-                content_selectors=['//div[@id="main"]'],
-            )
-
-    def test_invalid_url_scheme(self):
-        """Test base_dir with invalid URL scheme."""
-        # Now validation happens at initialization time with Pydantic HttpUrl
-        with pytest.raises(ValidationError, match=r"Input should be a valid URL"):
-            _ = SiteParserConfig(
-                base_url=HttpUrl("invalid-url"),  # No scheme
-                content_selectors=['//div[@id="main"]'],
-            )
-
-    def test_file_url(self):
-        """Test base_dir with file URL."""
-        # Now validation happens at initialization time with Pydantic HttpUrl
-        with pytest.raises(ValidationError, match=r"URL scheme should be 'http' or 'https'"):
-            _ = SiteParserConfig(
-                base_url=HttpUrl("file:///path/to/file.html"),
-                content_selectors=['//div[@id="main"]'],
-            )
+        # Test when no selectors match
+        html_content = """
+        <html>
+            <body>
+                <div class="other">Other content</div>
+            </body>
+        </html>
+        """
+        tree = lxml_html.fromstring(html_content)
+        element = config.get_content_selector(tree)
+        assert element is None
 
 
 class TestSiteParserConfig:
@@ -152,24 +137,66 @@ class TestSiteParserConfig:
 
     def test_default_values(self):
         """Test default values for SiteParserConfig."""
-        config = SiteParserConfig(
+        config = SiteConfig(
             base_url=HttpUrl("https://example.com"),
-            content_selectors=['//div[@id="main"]'],
         )
         assert str(config.base_url) == "https://example.com/"
-        assert config.title_selector == "//title"
-        assert config.fallback_to_body is True
         assert config.description is None
-        assert isinstance(config.markdown_config, HtmlToMarkdownConfig)
+        assert isinstance(config.parser_config, ParserConfig)
+        assert isinstance(config.crawler_config, CrawlerConfig)
+
+    def test_custom_values(self):
+        """Test SiteParserConfig with custom values."""
+        parser_config = ParserConfig(
+            title_selector="//h1",
+            content_selectors=['//div[@id="main"]'],
+            fallback_to_body=False,
+        )
+        crawler_config = CrawlerConfig(
+            delay_between_requests=2.0,
+            max_concurrent=3,
+        )
+
+        config = SiteConfig(
+            base_url=HttpUrl("https://example.com"),
+            description="Test site",
+            parser_config=parser_config,
+            crawler_config=crawler_config,
+        )
+
+        assert str(config.base_url) == "https://example.com/"
+        assert config.description == "Test site"
+        assert config.parser_config.title_selector == "//h1"
+        assert config.crawler_config.delay_between_requests == 2.0
+
+    def test_base_dir_property(self):
+        """Test the base_dir property."""
+        config = SiteConfig(base_url=HttpUrl("https://example.com"))
+        assert config.base_dir == "example.com"
+
+        config = SiteConfig(base_url=HttpUrl("https://subdomain.example.com:8080"))
+        assert config.base_dir == "subdomain.example.com"
+
+    def test_invalid_base_url(self):
+        """Test invalid base URLs."""
+        # Now validation happens at initialization time with Pydantic HttpUrl
+        with pytest.raises(ValidationError, match=r"Input should be a valid URL"):
+            SiteConfig(base_url="not-a-url")  # type: ignore[arg-type]
+
+        with pytest.raises(ValidationError, match=r"URL scheme should be 'http' or 'https'"):
+            SiteConfig(base_url="ftp://example.com")  # type: ignore[arg-type]
 
     def test_get_content_selector(self):
-        """Test the get_content_selector method."""
+        """Test the get_content_selector method delegation."""
         from lxml import html as lxml_html
 
-        # Create a test config
-        config = SiteParserConfig(
-            base_url=HttpUrl("https://example.com"),
+        # Create a test config with parser config
+        parser_config = ParserConfig(
             content_selectors=['//div[@id="main"]', '//div[@class="content"]', "//article"],
+        )
+        config = SiteConfig(
+            base_url=HttpUrl("https://example.com"),
+            parser_config=parser_config,
         )
 
         # Create a test HTML tree
@@ -247,12 +274,14 @@ class TestParserConfigRegistry:
 
     def test_model_validation(self):
         """Test model validation."""
-        # Valid config with all required fields
+        # Valid config with all required fields using new structure
         config_data = {
             "sites": {
                 "test": {
                     "base_url": "https://example.com",
-                    "content_selectors": ["//div"],
+                    "parser_config": {
+                        "content_selectors": ["//div"],
+                    },
                 },
             },
         }
@@ -261,8 +290,6 @@ class TestParserConfigRegistry:
         assert str(registry.sites["test"].base_url) == "https://example.com/"
 
         # Invalid config (missing required fields)
-        from pydantic import ValidationError
-
         with pytest.raises(ValidationError):
             ParserConfigRegistry.model_validate(
                 {

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -83,22 +83,26 @@ class TestParser(unittest.TestCase):
                 "example": {
                     "base_url": f"https://{self.domain}",
                     "base_dir": self.domain,
-                    "title_selector": "//title",
-                    "content_selectors": [
-                        '//div[@id="main-content"]',
-                        '//div[@class="content"]',
-                        "//main",
-                    ],
-                    "fallback_to_body": True,
                     "description": "Example Website for Testing",
-                    "markdown_config": {"ignore_links": False, "body_width": 0},
+                    "parser_config": {
+                        "title_selector": "//title",
+                        "content_selectors": [
+                            '//div[@id="main-content"]',
+                            '//div[@class="content"]',
+                            "//main",
+                        ],
+                        "fallback_to_body": True,
+                        "markdown_config": {"ignore_links": False, "body_width": 0},
+                    },
                 },
                 "no_fallback": {
                     "base_url": f"https://{self.domain}",
                     "base_dir": self.domain,
-                    "title_selector": "//h1",
-                    "content_selectors": ['//div[@id="does-not-exist"]'],
-                    "fallback_to_body": False,
+                    "parser_config": {
+                        "title_selector": "//h1",
+                        "content_selectors": ['//div[@id="does-not-exist"]'],
+                        "fallback_to_body": False,
+                    },
                 },
             },
         }
@@ -130,9 +134,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual(self.parser.output_dir, os.path.join(self.output_dir, "example"))
 
         # Test config loaded correctly
-        self.assertEqual(self.parser.config.title_selector, "//title")
-        self.assertEqual(len(self.parser.config.content_selectors), 3)
-        self.assertTrue(self.parser.config.fallback_to_body)
+        self.assertEqual(self.parser.config.parser_config.title_selector, "//title")
+        self.assertEqual(len(self.parser.config.parser_config.content_selectors), 3)
+        self.assertTrue(self.parser.config.parser_config.fallback_to_body)
         self.assertEqual(self.parser.config.description, "Example Website for Testing")
 
     def test_init_with_invalid_site(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -545,9 +545,13 @@ class TestCli:
         # Mock site config
         mock_site_config = MagicMock()
         mock_site_config.description = "Finnish Immigration Service"
-        mock_site_config.title_selector = "h1"
-        mock_site_config.content_selectors = ["main", "article"]
-        mock_site_config.fallback_to_body = True
+
+        # Mock parser config within site config
+        mock_parser_config = MagicMock()
+        mock_parser_config.title_selector = "h1"
+        mock_parser_config.content_selectors = ["main", "article"]
+        mock_parser_config.fallback_to_body = True
+        mock_site_config.parser_config = mock_parser_config
 
         mock_config_instance.get_site_config.return_value = mock_site_config
         mock_config_manager.return_value = mock_config_instance


### PR DESCRIPTION
Update the site configuration to include a dedicated parser_config, ensuring consistency across related code and tests. This change enhances the organization of configuration settings for improved clarity and maintainability.