### PR TITLE
feat: add initial devcontainer configuration for Python 3

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"features": {
+		"ghcr.io/va-h/devcontainers-features/uv:1": {}
+	},
+	"postCreateCommand": "uv sync",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.pylint",
+				"ms-python.black-formatter"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new development container configuration for Python development. The configuration specifies the container image, features, and post-creation commands, as well as Visual Studio Code customizations.

Development container setup:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R19): Added a new configuration file for setting up a Python development container using the `mcr.microsoft.com/devcontainers/python:1-3.12-bullseye` image. Includes features like `uv` synchronization and installs VS Code extensions (`ms-python.python`, `ms-python.pylint`, `ms-python.black-formatter`) for Python development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a development container configuration to provide a pre-configured Python 3 environment with built-in linting and code formatting support for Visual Studio Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->