### PR TITLE
Add Phase 1 crawler discovery: manifest, sitemap-first discovery, scope config, run summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST
+/MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,10 @@ repos:
         args: [--py313-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.20
+    rev: v0.16.1
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter.
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ uv run tapio-crawler crawl migri --depth 0
 
 Then return to the repository root and run `mise run ingest -- --site migri`.
 
+`discover` builds a site's URL inventory (sitemap or bounded gap-crawl) into
+a separate manifest database; it doesn't write Markdown, so it isn't part of
+the ingest pipeline above. See [crawler/README.md](crawler/README.md#url-discovery-and-the-manifest).
+
 ### Troubleshooting
 
 - **“No relevant documents found”** — Run `mise run ingest` after a crawl and

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ packages = ["app"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,14 +1,10 @@
 """Shared fixtures for backend tests: RAG/agent unit tests and the FastAPI API tests."""
 
-import sys
 from collections.abc import Iterator
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 from fastapi.testclient import TestClient
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app.agents.router import AgentRouter
 from app.dependencies import get_agent_router, get_orchestrator

--- a/crawler/README.md
+++ b/crawler/README.md
@@ -34,3 +34,25 @@ When a site is due, Crawl4AI stores its persistent cache in
 `Last-Modified`) before rendering a cached page again. Mount `content/` as a
 persistent volume in deployment, or set `CRAWL4_AI_BASE_DIRECTORY` to another
 persistent location.
+
+## URL discovery and the manifest
+
+`discover` builds a site's URL inventory - separately from crawling and
+rendering - and records it in a durable, SQLite-backed manifest:
+
+```bash
+uv run tapio-crawler discover migri
+```
+
+For a source with a sitemap (`discovery.source: sitemap` in
+`site_configs.yaml`), this fetches the sitemap(s) directly, following one
+level of sitemap-index nesting and preserving each URL's `lastmod`. For a
+source with no sitemap, set `discovery.source: none` and
+`gap_crawl.enabled: true` with `seed_urls`; discovery then runs a bounded BFS
+crawl instead. Every discovered URL is scored against the site's `scope`
+config (`allowed_domains`, `include_url_patterns`, `exclude_url_patterns`) and
+upserted into the manifest with its eligibility.
+
+The manifest lives at `{TAPIO_CONTENT_DIR}/manifest.db` by default; override
+its path with `TAPIO_MANIFEST_PATH`. A discovery run never renders pages or
+writes Markdown - that remains `crawl`'s job.

--- a/crawler/pyproject.toml
+++ b/crawler/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = ["integration: test that exercises multiple crawler components"]
 
 [tool.ruff]

--- a/crawler/pyproject.toml
+++ b/crawler/pyproject.toml
@@ -106,7 +106,6 @@ ignore = [
     "FBT003", # typer.Option(False, ...) is the standard boolean-flag idiom
 ]
 "tests/*" = [
-    "ANN",     # tests are excluded from mypy and don't need type annotations
     "ARG001",  # unused fixture/mock arguments are normal in tests
     "ARG002",  # unused mock-override arguments are normal in tests
     "D",       # docstrings aren't required on test functions

--- a/crawler/pyproject.toml
+++ b/crawler/pyproject.toml
@@ -9,6 +9,7 @@ description = "Tapio's independently deployable content-collection service"
 requires-python = ">=3.14"
 dependencies = [
     "crawl4ai>=0.9.2,<0.10",
+    "httpx>=0.28.1",
     "pydantic>=2.13.4",
     "pyyaml>=6.0.1",
     "python-frontmatter>=1.1.0",

--- a/crawler/pyproject.toml
+++ b/crawler/pyproject.toml
@@ -34,5 +34,100 @@ dev = [
 testpaths = ["tests"]
 markers = ["integration: test that exercises multiple crawler components"]
 
+[tool.ruff]
+line-length = 120
+target-version = "py314"
+
 [tool.ruff.lint]
-ignore = ["BLE001"]
+select = [
+    "A",     # flake8-builtins
+    "ANN",   # flake8-annotations
+    "ARG",   # flake8-unused-arguments
+    "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "BLE",   # flake8-blind-except
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe complexity
+    "D",     # pydocstyle
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle errors
+    "EM",    # flake8-errmsg
+    "EXE",   # flake8-executable
+    "F",     # pyflakes
+    "FA",    # flake8-future-annotations
+    "FBT",   # flake8-boolean-trap
+    "FIX",   # flake8-fixme
+    "FLY",   # flynt
+    "FURB",  # refurb
+    "G",     # flake8-logging-format
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "ISC",   # flake8-implicit-str-concat
+    "LOG",   # flake8-logging
+    "N",     # pep8-naming
+    "PERF",  # perflint
+    "PGH",   # pygrep-hooks
+    "PIE",   # flake8-pie
+    "PL",    # pylint
+    "PT",    # flake8-pytest-style
+    "PTH",   # flake8-use-pathlib
+    "RET",   # flake8-return
+    "RSE",   # flake8-raise
+    "RUF",   # ruff-specific rules
+    "S",     # flake8-bandit
+    "SIM",   # flake8-simplify
+    "SLF",   # flake8-self
+    "SLOT",  # flake8-slots
+    "T10",   # flake8-debugger
+    "T20",   # flake8-print
+    "TC",    # flake8-type-checking
+    "TD",    # flake8-todos
+    "TID",   # flake8-tidy-imports
+    "TRY",   # tryceratops
+    "UP",    # pyupgrade
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
+]
+ignore = [
+    "ANN401",   # Any is used intentionally for flexible metadata dicts
+    "ASYNC109", # timeout kwargs mirror httpx.AsyncClient's own idiom, not asyncio.timeout
+    "BLE001",   # broad except-and-log-and-continue is intentional throughout the crawler
+    "COM812",   # trailing-comma rules conflict with the ruff formatter
+    "ISC001",   # implicit-str-concat conflicts with the ruff formatter
+    "TC001",    # first-party imports behind TYPE_CHECKING breaks Pydantic runtime introspection
+    "TC002",    # same risk as TC001, for third-party imports
+    "TC003",    # same risk as TC001, for standard-library imports
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tapio_crawler/cli.py" = [
+    "FBT001", # typer options are declared as boolean positional parameters
+    "FBT003", # typer.Option(False, ...) is the standard boolean-flag idiom
+]
+"tests/*" = [
+    "ANN",     # tests are excluded from mypy and don't need type annotations
+    "ARG001",  # unused fixture/mock arguments are normal in tests
+    "ARG002",  # unused mock-override arguments are normal in tests
+    "D",       # docstrings aren't required on test functions
+    "INP001",  # tests intentionally use implicit namespace packages
+    "PLC0415", # local imports for mocking/patching timing are idiomatic in tests
+    "PLR0913", # test functions naturally take many fixture arguments
+    "PLR0917", # mock-heavy test functions naturally have many positional arguments
+    "PLR2004", # magic values in test assertions/fixtures are fine
+    "PT009",   # some test classes intentionally use unittest.TestCase-style assertions
+    "PTH",     # os.path-based temp file/dir handling in test fixtures is fine
+    "S101",    # assert is the standard pytest idiom
+    "SLF001",  # tests intentionally exercise private members
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pylint]
+max-args = 6
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/crawler/tapio_crawler/cli.py
+++ b/crawler/tapio_crawler/cli.py
@@ -1,9 +1,13 @@
 """CLI for the content-collection service."""
 
+import asyncio
+
 import typer
 
 from tapio_crawler.config import ConfigManager
 from tapio_crawler.crawler import CrawlerRunner
+from tapio_crawler.discovery.runner import DiscoveryRunner, MisconfiguredDiscoveryError
+from tapio_crawler.manifest.store import ManifestStore
 
 app = typer.Typer(help="Collect and normalize source content for Tapio.")
 
@@ -59,6 +63,37 @@ def crawl(
         f"near-empty {summary.get('near_empty', 0)}; "
         f"fallback recoveries {summary.get('fallback_recoveries', 0)}; "
         f"HTTP statuses: {status_codes}; cache: {cache_statuses}.",
+    )
+
+
+@app.command()
+def discover(site: str) -> None:
+    """Discover a site's URL inventory and record it in the manifest."""
+    config = ConfigManager()
+    site_config = config.get_site_config(site)
+    store = ManifestStore()
+    try:
+        runner = DiscoveryRunner(store)
+        try:
+            summary = asyncio.run(runner.run(site, site_config))
+        except MisconfiguredDiscoveryError as error:
+            typer.echo(str(error))
+            raise typer.Exit(code=1) from error
+    finally:
+        store.close()
+
+    excluded = (
+        ", ".join(
+            f"{reason}={count}" for reason, count in summary.excluded_by_reason.items()
+        )
+        or "none"
+    )
+    status = "complete" if summary.complete else "incomplete"
+    typer.echo(
+        f"Discovery run {summary.run_id} for {site}: {status}. "
+        f"Discovered {summary.discovered}; eligible {summary.eligible}; "
+        f"excluded: {excluded}; "
+        f"child sitemaps fetched {summary.child_sitemaps_fetched}.",
     )
 
 

--- a/crawler/tapio_crawler/cli.py
+++ b/crawler/tapio_crawler/cli.py
@@ -43,19 +43,9 @@ def crawl(
             "Use --force to crawl it now.",
         )
         return
-    status_codes = (
-        ", ".join(
-            f"{status}={count}"
-            for status, count in summary.get("status_codes", {}).items()
-        )
-        or "none"
-    )
+    status_codes = ", ".join(f"{status}={count}" for status, count in summary.get("status_codes", {}).items()) or "none"
     cache_statuses = (
-        ", ".join(
-            f"{status}={count}"
-            for status, count in summary.get("cache_statuses", {}).items()
-        )
-        or "none"
+        ", ".join(f"{status}={count}" for status, count in summary.get("cache_statuses", {}).items()) or "none"
     )
     typer.echo(
         f"Wrote {len(results)} Markdown documents for {site}. "
@@ -68,7 +58,15 @@ def crawl(
 
 @app.command()
 def discover(site: str) -> None:
-    """Discover a site's URL inventory and record it in the manifest."""
+    """Discover a site's URL inventory and record it in the manifest.
+
+    Args:
+        site: Name of the configured source site to discover.
+
+    Raises:
+        typer.Exit: With code 1 if the site has no configured way to
+            discover URLs (see ``MisconfiguredDiscoveryError``).
+    """
     config = ConfigManager()
     site_config = config.get_site_config(site)
     store = ManifestStore()
@@ -82,12 +80,7 @@ def discover(site: str) -> None:
     finally:
         store.close()
 
-    excluded = (
-        ", ".join(
-            f"{reason}={count}" for reason, count in summary.excluded_by_reason.items()
-        )
-        or "none"
-    )
+    excluded = ", ".join(f"{reason}={count}" for reason, count in summary.excluded_by_reason.items()) or "none"
     status = "complete" if summary.complete else "incomplete"
     typer.echo(
         f"Discovery run {summary.run_id} for {site}: {status}. "

--- a/crawler/tapio_crawler/config/__init__.py
+++ b/crawler/tapio_crawler/config/__init__.py
@@ -7,7 +7,11 @@ for source-site collection and Markdown output.
 from tapio_crawler.config.config_manager import ConfigManager
 from tapio_crawler.config.config_models import (
     CrawlerConfig,
+    DiscoveryConfig,
+    GapCrawlConfig,
     MarkdownConfig,
+    PolitenessConfig,
+    ScopeConfig,
     SiteConfig,
     SiteConfigRegistry,
 )
@@ -15,7 +19,11 @@ from tapio_crawler.config.config_models import (
 __all__ = [
     "ConfigManager",
     "CrawlerConfig",
+    "DiscoveryConfig",
+    "GapCrawlConfig",
     "MarkdownConfig",
+    "PolitenessConfig",
+    "ScopeConfig",
     "SiteConfig",
     "SiteConfigRegistry",
 ]

--- a/crawler/tapio_crawler/config/config_manager.py
+++ b/crawler/tapio_crawler/config/config_manager.py
@@ -13,6 +13,7 @@ from tapio_crawler.config.config_models import SiteConfig, SiteConfigRegistry
 
 
 def _raise_empty_config_error() -> None:
+    """Raise ValueError because the loaded configuration file is empty."""
     msg = "Configuration file is empty"
     raise ValueError(msg)
 

--- a/crawler/tapio_crawler/config/config_manager.py
+++ b/crawler/tapio_crawler/config/config_manager.py
@@ -12,6 +12,11 @@ import yaml
 from tapio_crawler.config.config_models import SiteConfig, SiteConfigRegistry
 
 
+def _raise_empty_config_error() -> None:
+    msg = "Configuration file is empty"
+    raise ValueError(msg)
+
+
 class ConfigManager:
     """Manages configuration for the Tapio application.
 
@@ -56,8 +61,7 @@ class ConfigManager:
             with Path(config_path).open(encoding="utf-8") as file:
                 config_data = yaml.safe_load(file)
                 if config_data is None:
-                    msg = "Configuration file is empty"
-                    raise ValueError(msg)
+                    _raise_empty_config_error()
                 return SiteConfigRegistry(**config_data)
         except FileNotFoundError:
             self.logger.exception("Configuration file not found: %s", config_path)

--- a/crawler/tapio_crawler/config/config_models.py
+++ b/crawler/tapio_crawler/config/config_models.py
@@ -36,11 +36,6 @@ class DiscoveryConfig(BaseModel):
     source: Literal["sitemap", "none"] = "none"
     # Empty: read ``Sitemap:`` entries from the source's robots.txt instead.
     sitemap_urls: list[str] = Field(default_factory=list)
-    cache_ttl_hours: Annotated[int, Field(ge=1, le=8_760)] = 24
-    validate_sitemap_lastmod: bool = True
-    # Requires a recorded, per-source correlation measurement before flipping
-    # to True (see docs/specs/crawler-improvements.md Requirement 2).
-    trust_lastmod: bool = False
 
 
 class ScopeConfig(BaseModel):

--- a/crawler/tapio_crawler/config/config_models.py
+++ b/crawler/tapio_crawler/config/config_models.py
@@ -1,9 +1,15 @@
 """Configuration models for Crawl4AI collection jobs."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, HttpUrl, model_validator
+
+# Identifies Tapio to source operators instead of a spoofed browser string.
+DEFAULT_USER_AGENT = (
+    "TapioBot/1.0 (+https://github.com/Finntegrate/tapio; "
+    "nonprofit immigration-guidance assistant; contact via repository)"
+)
 
 
 class MarkdownConfig(BaseModel):
@@ -15,6 +21,46 @@ class MarkdownConfig(BaseModel):
     unicode_snob: bool = True
     ignore_images: bool = False
     ignore_tables: bool = False
+
+
+class PolitenessConfig(BaseModel):
+    """Identification and rate-limiting posture for one source."""
+
+    respect_crawl_delay: bool = True
+    user_agent: str = DEFAULT_USER_AGENT
+
+
+class DiscoveryConfig(BaseModel):
+    """How a source's URL inventory is discovered."""
+
+    source: Literal["sitemap", "none"] = "none"
+    # Empty: read ``Sitemap:`` entries from the source's robots.txt instead.
+    sitemap_urls: list[str] = Field(default_factory=list)
+    cache_ttl_hours: Annotated[int, Field(ge=1, le=8_760)] = 24
+    validate_sitemap_lastmod: bool = True
+    # Requires a recorded, per-source correlation measurement before flipping
+    # to True (see docs/specs/crawler-improvements.md Requirement 2).
+    trust_lastmod: bool = False
+
+
+class ScopeConfig(BaseModel):
+    """Domain, language, and path rules bounding a source's eligible URLs."""
+
+    allowed_domains: list[str] = Field(default_factory=list)
+    languages: list[str] = Field(default_factory=list)
+    include_url_patterns: list[str] = Field(default_factory=list)
+    exclude_url_patterns: list[str] = Field(default_factory=list)
+    allowed_content_types: list[str] = Field(default_factory=lambda: ["text/html"])
+
+
+class GapCrawlConfig(BaseModel):
+    """Bounded deep-crawl discovery settings for one source."""
+
+    enabled: bool = False
+    seed_urls: list[str] = Field(default_factory=list)
+    strategy: Literal["bfs"] = "bfs"
+    max_depth: Annotated[int, Field(ge=0, le=10)] = 2
+    max_pages: Annotated[int, Field(ge=1, le=1_000)] = 100
 
 
 class CrawlerConfig(BaseModel):
@@ -33,6 +79,11 @@ class CrawlerConfig(BaseModel):
     remove_consent_popups: bool = False
     remove_overlay_elements: bool = False
     markdown_config: MarkdownConfig = Field(default_factory=MarkdownConfig)
+    robots_policy: Literal["require"] = "require"
+    politeness: PolitenessConfig = Field(default_factory=PolitenessConfig)
+    discovery: DiscoveryConfig = Field(default_factory=DiscoveryConfig)
+    scope: ScopeConfig = Field(default_factory=ScopeConfig)
+    gap_crawl: GapCrawlConfig = Field(default_factory=GapCrawlConfig)
 
     @model_validator(mode="after")
     def validate_delay_range(self) -> CrawlerConfig:

--- a/crawler/tapio_crawler/config/settings.py
+++ b/crawler/tapio_crawler/config/settings.py
@@ -1,6 +1,7 @@
 """Filesystem and network defaults owned by the crawler service."""
 
 import os
+from pathlib import Path
 
 # An external volume can supply this path; local development uses the
 # monorepo's adjacent ``content/`` directory by default.
@@ -13,7 +14,7 @@ DEFAULT_CRAWL4AI_BASE_DIRECTORY = DEFAULT_CONTENT_DIR
 # across sites, one row per (site_name, canonical_url).
 DEFAULT_MANIFEST_PATH = os.environ.get(
     "TAPIO_MANIFEST_PATH",
-    os.path.join(DEFAULT_CONTENT_DIR, "manifest.db"),
+    str(Path(DEFAULT_CONTENT_DIR) / "manifest.db"),
 )
 
 # Default directory paths. Crawl4AI writes directly to parsed Markdown.

--- a/crawler/tapio_crawler/config/settings.py
+++ b/crawler/tapio_crawler/config/settings.py
@@ -9,6 +9,12 @@ DEFAULT_CONTENT_DIR = os.environ.get("TAPIO_CONTENT_DIR", "../content")
 # the same persistent volume as collected Markdown unless deployment overrides
 # ``CRAWL4_AI_BASE_DIRECTORY``.
 DEFAULT_CRAWL4AI_BASE_DIRECTORY = DEFAULT_CONTENT_DIR
+# SQLite-backed URL manifest (see docs/specs/crawler-improvements.md). Shared
+# across sites, one row per (site_name, canonical_url).
+DEFAULT_MANIFEST_PATH = os.environ.get(
+    "TAPIO_MANIFEST_PATH",
+    os.path.join(DEFAULT_CONTENT_DIR, "manifest.db"),
+)
 
 # Default directory paths. Crawl4AI writes directly to parsed Markdown.
 DEFAULT_DIRS = {

--- a/crawler/tapio_crawler/config/site_configs.yaml
+++ b/crawler/tapio_crawler/config/site_configs.yaml
@@ -1,4 +1,8 @@
 # Default configuration for Crawl4AI source collection.
+#
+# See docs/specs/crawler-improvements.md for the discovery/scope/politeness
+# schema. `trust_lastmod` stays `false` for every source until Phase 0
+# confirms lastmod-to-content-change correlation per source.
 sites:
   migri:
     base_url: "https://migri.fi"
@@ -7,11 +11,32 @@ sites:
       max_depth: 1
       max_pages: 50
       recrawl_interval_hours: 720
-      min_delay: 1.0
-      max_delay: 3.0
-      max_concurrent: 3
+      # migri.fi's robots.txt declares a 5s Crawl-delay; this is the floor
+      # under which the shared rate limiter will never schedule a request.
+      min_delay: 5.0
+      max_delay: 8.0
+      max_concurrent: 2
       remove_consent_popups: true
       remove_overlay_elements: true
+      robots_policy: require
+      politeness:
+        respect_crawl_delay: true
+      discovery:
+        source: sitemap
+        sitemap_urls: []
+        cache_ttl_hours: 24
+        validate_sitemap_lastmod: true
+        trust_lastmod: false
+      scope:
+        allowed_domains: ["migri.fi", "www.migri.fi"]
+        languages: ["en"]
+        include_url_patterns: ["/en/*"]
+        exclude_url_patterns:
+          - "*/search*"
+          - "*/login*"
+          - "*/asiointi*"
+          - "*?*utm_*"
+        allowed_content_types: ["text/html"]
 
   # Example configuration for TE Services website
   tyomarkkinatori:
@@ -26,6 +51,28 @@ sites:
       max_concurrent: 3
       remove_consent_popups: true
       remove_overlay_elements: true
+      robots_policy: require
+      politeness:
+        respect_crawl_delay: true
+      discovery:
+        # No Sitemap: entry in robots.txt and /sitemap.xml returns 404.
+        # Bounded deep crawl is the only discovery path for this source.
+        source: none
+      scope:
+        allowed_domains: ["tyomarkkinatori.fi"]
+        languages: ["en"]
+        include_url_patterns: ["/en/*"]
+        exclude_url_patterns:
+          - "*/search*"
+          - "*/login*"
+          - "*?*utm_*"
+        allowed_content_types: ["text/html"]
+      gap_crawl:
+        enabled: true
+        seed_urls: ["https://tyomarkkinatori.fi/en"]
+        strategy: bfs
+        max_depth: 4
+        max_pages: 300
 
   # Example configuration for Kela website
   kela:
@@ -39,6 +86,24 @@ sites:
       max_delay: 3.0
       max_concurrent: 4
       css_selector: "#content-root"
+      robots_policy: require
+      politeness:
+        respect_crawl_delay: true
+      discovery:
+        source: sitemap
+        sitemap_urls: []
+        cache_ttl_hours: 24
+        validate_sitemap_lastmod: true
+        trust_lastmod: false
+      scope:
+        allowed_domains: ["kela.fi", "www.kela.fi"]
+        languages: ["en"]
+        include_url_patterns: ["/en/*"]
+        exclude_url_patterns:
+          - "*/search*"
+          - "*/login*"
+          - "*?*utm_*"
+        allowed_content_types: ["text/html"]
 
   # Example configuration for Vero website
   vero:
@@ -53,6 +118,24 @@ sites:
       max_concurrent: 4
       remove_consent_popups: true
       remove_overlay_elements: true
+      robots_policy: require
+      politeness:
+        respect_crawl_delay: true
+      discovery:
+        source: sitemap
+        sitemap_urls: []
+        cache_ttl_hours: 24
+        validate_sitemap_lastmod: true
+        trust_lastmod: false
+      scope:
+        allowed_domains: ["vero.fi", "www.vero.fi"]
+        languages: ["en"]
+        include_url_patterns: ["/en/*"]
+        exclude_url_patterns:
+          - "*/search*"
+          - "*/login*"
+          - "*?*utm_*"
+        allowed_content_types: ["text/html"]
 
   # Example configuration for DVV website
   dvv:
@@ -62,8 +145,27 @@ sites:
       max_depth: 1
       max_pages: 50
       recrawl_interval_hours: 720
-      min_delay: 1.0
-      max_delay: 3.0
-      max_concurrent: 4
+      # dvv.fi's robots.txt declares a 5s Crawl-delay; see migri above.
+      min_delay: 5.0
+      max_delay: 8.0
+      max_concurrent: 2
       remove_consent_popups: true
       remove_overlay_elements: true
+      robots_policy: require
+      politeness:
+        respect_crawl_delay: true
+      discovery:
+        source: sitemap
+        sitemap_urls: []
+        cache_ttl_hours: 24
+        validate_sitemap_lastmod: true
+        trust_lastmod: false
+      scope:
+        allowed_domains: ["dvv.fi", "www.dvv.fi"]
+        languages: ["en"]
+        include_url_patterns: ["/en/*"]
+        exclude_url_patterns:
+          - "*/search*"
+          - "*/login*"
+          - "*?*utm_*"
+        allowed_content_types: ["text/html"]

--- a/crawler/tapio_crawler/config/site_configs.yaml
+++ b/crawler/tapio_crawler/config/site_configs.yaml
@@ -1,8 +1,7 @@
 # Default configuration for Crawl4AI source collection.
 #
 # See docs/specs/crawler-improvements.md for the discovery/scope/politeness
-# schema. `trust_lastmod` stays `false` for every source until Phase 0
-# confirms lastmod-to-content-change correlation per source.
+# schema.
 sites:
   migri:
     base_url: "https://migri.fi"
@@ -24,9 +23,6 @@ sites:
       discovery:
         source: sitemap
         sitemap_urls: []
-        cache_ttl_hours: 24
-        validate_sitemap_lastmod: true
-        trust_lastmod: false
       scope:
         allowed_domains: ["migri.fi", "www.migri.fi"]
         languages: ["en"]
@@ -92,9 +88,6 @@ sites:
       discovery:
         source: sitemap
         sitemap_urls: []
-        cache_ttl_hours: 24
-        validate_sitemap_lastmod: true
-        trust_lastmod: false
       scope:
         allowed_domains: ["kela.fi", "www.kela.fi"]
         languages: ["en"]
@@ -124,9 +117,6 @@ sites:
       discovery:
         source: sitemap
         sitemap_urls: []
-        cache_ttl_hours: 24
-        validate_sitemap_lastmod: true
-        trust_lastmod: false
       scope:
         allowed_domains: ["vero.fi", "www.vero.fi"]
         languages: ["en"]
@@ -157,9 +147,6 @@ sites:
       discovery:
         source: sitemap
         sitemap_urls: []
-        cache_ttl_hours: 24
-        validate_sitemap_lastmod: true
-        trust_lastmod: false
       scope:
         allowed_domains: ["dvv.fi", "www.dvv.fi"]
         languages: ["en"]

--- a/crawler/tapio_crawler/crawler/crawler.py
+++ b/crawler/tapio_crawler/crawler/crawler.py
@@ -75,9 +75,7 @@ class Crawl4AICrawler:
         self.site_name = site_name
         self.site_config = site_config
         self.config = site_config.crawler_config
-        self.output_dir = (
-            Path(DEFAULT_CONTENT_DIR) / site_name / DEFAULT_DIRS["PARSED_DIR"]
-        )
+        self.output_dir = Path(DEFAULT_CONTENT_DIR) / site_name / DEFAULT_DIRS["PARSED_DIR"]
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.state_path = self.output_dir.parent / "crawl_state.json"
         self.summary: CrawlSummary = self._empty_summary()
@@ -108,9 +106,7 @@ class Crawl4AICrawler:
             target_elements=(
                 cast(
                     "list[str]",
-                    self.config.target_elements or None
-                    if apply_content_cleanup
-                    else None,
+                    self.config.target_elements or None if apply_content_cleanup else None,
                 )
             ),
             markdown_generator=markdown_generator,
@@ -123,12 +119,8 @@ class Crawl4AICrawler:
                 if deep_crawl
                 else None
             ),
-            remove_consent_popups=(
-                self.config.remove_consent_popups if apply_content_cleanup else False
-            ),
-            remove_overlay_elements=(
-                self.config.remove_overlay_elements if apply_content_cleanup else False
-            ),
+            remove_consent_popups=(self.config.remove_consent_popups if apply_content_cleanup else False),
+            remove_overlay_elements=(self.config.remove_overlay_elements if apply_content_cleanup else False),
             # BFSDeepCrawlStrategy uses these when it calls arun_many for each level.
             mean_delay=self.config.min_delay,
             max_range=self.config.max_delay - self.config.min_delay,
@@ -210,17 +202,17 @@ class Crawl4AICrawler:
                     "Retrying near-empty Crawl4AI result for %s without cleanup",
                     raw_result.url,
                 )
-                raw_result = await self._fallback_result(crawler, raw_result.url)
-                markdown = self._markdown(raw_result)
-                if not raw_result.success or (
-                    len(markdown.strip()) < self.config.minimum_content_length
-                ):
+                fallback_result = await self._fallback_result(crawler, raw_result.url)
+                markdown = self._markdown(fallback_result)
+                if not fallback_result.success or (len(markdown.strip()) < self.config.minimum_content_length):
                     logger.warning(
                         "Skipping unrecoverable near-empty result for %s",
                         raw_result.url,
                     )
                     continue
                 self.summary["fallback_recoveries"] += 1
+                saved_results.append(self._save_result(fallback_result, markdown))
+                continue
 
             saved_results.append(self._save_result(raw_result, markdown))
         return saved_results
@@ -248,14 +240,10 @@ class Crawl4AICrawler:
         status_code = getattr(raw_result, "status_code", None)
         if status_code is not None:
             status = str(status_code)
-            self.summary["status_codes"][status] = (
-                self.summary["status_codes"].get(status, 0) + 1
-            )
+            self.summary["status_codes"][status] = self.summary["status_codes"].get(status, 0) + 1
         cache_status = getattr(raw_result, "cache_status", None)
         if cache_status:
-            self.summary["cache_statuses"][cache_status] = (
-                self.summary["cache_statuses"].get(cache_status, 0) + 1
-            )
+            self.summary["cache_statuses"][cache_status] = self.summary["cache_statuses"].get(cache_status, 0) + 1
 
     def _is_due(self) -> bool:
         """Return whether this site has passed its successful-crawl interval."""

--- a/crawler/tapio_crawler/crawler/runner.py
+++ b/crawler/tapio_crawler/crawler/runner.py
@@ -10,6 +10,7 @@ class CrawlerRunner:
     """Run one configured Crawl4AI collection job."""
 
     def __init__(self) -> None:
+        """Initialize the runner with no prior run summary."""
         self.last_summary: CrawlSummary | None = None
 
     async def run_async(

--- a/crawler/tapio_crawler/discovery/__init__.py
+++ b/crawler/tapio_crawler/discovery/__init__.py
@@ -1,0 +1,4 @@
+"""Discovery-time infrastructure: robots handling, rate limiting, and URL inventory.
+
+Shared by sitemap discovery, bounded gap-crawl discovery, and (later) rendering.
+"""

--- a/crawler/tapio_crawler/discovery/gap_crawl.py
+++ b/crawler/tapio_crawler/discovery/gap_crawl.py
@@ -22,6 +22,7 @@ from crawl4ai.deep_crawling.filters import (
 from crawl4ai.models import CrawlResultContainer
 
 from tapio_crawler.config.config_models import GapCrawlConfig, ScopeConfig
+from tapio_crawler.discovery.rate_limiter import HostRateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -39,11 +40,15 @@ async def discover_via_gap_crawl(
     scope: ScopeConfig,
     *,
     user_agent: str,
-    min_delay: float,
-    max_delay: float,
+    rate_limiter: HostRateLimiter,
     max_concurrent: int,
 ) -> GapCrawlResult:
-    """Run a bounded BFS crawl to discover URLs when no sitemap exists."""
+    """Run a bounded BFS crawl to discover URLs when no sitemap exists.
+
+    Reuses ``rate_limiter``'s current delay window - shared with any robots
+    or sitemap fetches already made for this host - rather than resetting
+    host spacing with its own values.
+    """
     if not gap_crawl.enabled or not gap_crawl.seed_urls:
         return GapCrawlResult(complete=False)
 
@@ -55,8 +60,8 @@ async def discover_via_gap_crawl(
             filter_chain=FilterChain(_build_filters(scope)),
         ),
         cache_mode=CacheMode.BYPASS,
-        mean_delay=min_delay,
-        max_range=max(0.0, max_delay - min_delay),
+        mean_delay=rate_limiter.min_delay,
+        max_range=max(0.0, rate_limiter.max_delay - rate_limiter.min_delay),
         semaphore_count=max_concurrent,
         verbose=False,
     )
@@ -73,12 +78,12 @@ async def discover_via_gap_crawl(
     try:
         async with AsyncWebCrawler(config=browser_config) as crawler:
             raw_results = cast(
-                "CrawlResultContainer",
-                await crawler.arun(gap_crawl.seed_urls[0], config=run_config),
+                "list[CrawlResultContainer]",
+                await crawler.arun_many(gap_crawl.seed_urls, config=run_config),
             )
             discovered = [result.url for result in raw_results if result.success]
     except Exception:
-        logger.exception("Gap-crawl discovery failed for %s", gap_crawl.seed_urls[0])
+        logger.exception("Gap-crawl discovery failed for %s", gap_crawl.seed_urls)
         complete = False
 
     return GapCrawlResult(urls=discovered, complete=complete)

--- a/crawler/tapio_crawler/discovery/gap_crawl.py
+++ b/crawler/tapio_crawler/discovery/gap_crawl.py
@@ -1,0 +1,97 @@
+"""Bounded deep-crawl discovery: the only discovery path when no sitemap exists.
+
+Discovery-only for Phase 1 - it records discovered, in-scope URLs but does
+not persist rendered Markdown (that is Requirement 3/Phase 2's job).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
+from crawl4ai.deep_crawling import BFSDeepCrawlStrategy
+from crawl4ai.deep_crawling.filters import (
+    ContentTypeFilter,
+    DomainFilter,
+    FilterChain,
+    URLFilter,
+    URLPatternFilter,
+)
+from crawl4ai.models import CrawlResultContainer
+
+from tapio_crawler.config.config_models import GapCrawlConfig, ScopeConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GapCrawlResult:
+    """Discovered URLs from one bounded deep-crawl discovery pass."""
+
+    urls: list[str] = field(default_factory=list)
+    complete: bool = True
+
+
+async def discover_via_gap_crawl(
+    gap_crawl: GapCrawlConfig,
+    scope: ScopeConfig,
+    *,
+    user_agent: str,
+    min_delay: float,
+    max_delay: float,
+    max_concurrent: int,
+) -> GapCrawlResult:
+    """Run a bounded BFS crawl to discover URLs when no sitemap exists."""
+    if not gap_crawl.enabled or not gap_crawl.seed_urls:
+        return GapCrawlResult(complete=False)
+
+    run_config = CrawlerRunConfig(
+        deep_crawl_strategy=BFSDeepCrawlStrategy(
+            max_depth=gap_crawl.max_depth,
+            max_pages=gap_crawl.max_pages,
+            include_external=False,
+            filter_chain=FilterChain(_build_filters(scope)),
+        ),
+        cache_mode=CacheMode.BYPASS,
+        mean_delay=min_delay,
+        max_range=max(0.0, max_delay - min_delay),
+        semaphore_count=max_concurrent,
+        verbose=False,
+    )
+    browser_config = BrowserConfig(
+        browser_type="chromium",
+        chrome_channel="chrome",
+        headless=True,
+        user_agent=user_agent,
+        verbose=False,
+    )
+
+    discovered: list[str] = []
+    complete = True
+    try:
+        async with AsyncWebCrawler(config=browser_config) as crawler:
+            raw_results = cast(
+                "CrawlResultContainer",
+                await crawler.arun(gap_crawl.seed_urls[0], config=run_config),
+            )
+            discovered = [result.url for result in raw_results if result.success]
+    except Exception:
+        logger.exception("Gap-crawl discovery failed for %s", gap_crawl.seed_urls[0])
+        complete = False
+
+    return GapCrawlResult(urls=discovered, complete=complete)
+
+
+def _build_filters(scope: ScopeConfig) -> list[URLFilter]:
+    filters: list[URLFilter] = []
+    if scope.allowed_domains:
+        filters.append(DomainFilter(allowed_domains=scope.allowed_domains))
+    if scope.include_url_patterns:
+        filters.append(
+            URLPatternFilter(patterns=cast("Any", scope.include_url_patterns)),
+        )
+    if scope.allowed_content_types:
+        filters.append(ContentTypeFilter(allowed_types=scope.allowed_content_types))
+    return filters

--- a/crawler/tapio_crawler/discovery/gap_crawl.py
+++ b/crawler/tapio_crawler/discovery/gap_crawl.py
@@ -77,11 +77,13 @@ async def discover_via_gap_crawl(
     complete = True
     try:
         async with AsyncWebCrawler(config=browser_config) as crawler:
+            await rate_limiter.wait_for_turn()
             raw_results = cast(
                 "list[CrawlResultContainer]",
                 await crawler.arun_many(gap_crawl.seed_urls, config=run_config),
             )
             discovered = [result.url for result in raw_results if result.success]
+            complete = all(result.success for result in raw_results)
     except Exception:
         logger.exception("Gap-crawl discovery failed for %s", gap_crawl.seed_urls)
         complete = False

--- a/crawler/tapio_crawler/discovery/rate_limiter.py
+++ b/crawler/tapio_crawler/discovery/rate_limiter.py
@@ -61,6 +61,14 @@ class HostRateLimiter:
         max_delay: float,
         max_suspension_seconds: float = DEFAULT_MAX_SUSPENSION_SECONDS,
     ) -> None:
+        """Initialize the limiter with its politeness delay bounds.
+
+        Args:
+            min_delay: Minimum delay, in seconds, between requests to the host.
+            max_delay: Maximum delay, in seconds, between requests to the host.
+            max_suspension_seconds: Upper bound applied to any ``Retry-After``
+                suspension.
+        """
         self.min_delay = min_delay
         self.max_delay = max_delay
         self.max_suspension_seconds = max_suspension_seconds

--- a/crawler/tapio_crawler/discovery/rate_limiter.py
+++ b/crawler/tapio_crawler/discovery/rate_limiter.py
@@ -1,0 +1,118 @@
+"""A per-host rate limiter shared across every discovery-time request type.
+
+Enforces a source's ``Crawl-delay`` floor under its configured delay window
+and treats a ``429``/``503`` ``Retry-After`` as extending the same per-host
+suspension for every pending and future request, not just the retried URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+DEFAULT_MAX_SUSPENSION_SECONDS = 60 * 60  # 1 hour cap on Retry-After
+
+
+@dataclass
+class EffectiveDelay:
+    """The min/max delay window actually used for one host's requests."""
+
+    min_delay: float
+    max_delay: float
+
+
+def resolve_effective_delay(
+    *,
+    configured_min_delay: float,
+    configured_max_delay: float,
+    crawl_delay: float | None,
+) -> EffectiveDelay:
+    """Raise the configured delay window to respect a declared Crawl-delay.
+
+    A successfully parsed ``crawl_delay`` becomes a hard floor under
+    ``configured_min_delay``. If that floor would exceed
+    ``configured_max_delay``, the maximum is raised to match it (a fixed
+    per-host delay, no jitter) instead of producing a negative jitter range.
+    A missing ``crawl_delay`` leaves the configured window unchanged.
+    """
+    if crawl_delay is None:
+        return EffectiveDelay(configured_min_delay, configured_max_delay)
+    effective_min = max(configured_min_delay, crawl_delay)
+    effective_max = max(configured_max_delay, effective_min)
+    return EffectiveDelay(effective_min, effective_max)
+
+
+class HostRateLimiter:
+    """Serialize requests to one host behind a shared politeness delay.
+
+    One instance must be shared across every request type against a host -
+    robots/sitemap fetches, gap-crawl discovery, rendering, and retries -
+    so a ``Retry-After`` suspension or ``Crawl-delay`` floor applies
+    uniformly rather than being scoped to one mechanism.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_delay: float,
+        max_delay: float,
+        max_suspension_seconds: float = DEFAULT_MAX_SUSPENSION_SECONDS,
+    ) -> None:
+        self.min_delay = min_delay
+        self.max_delay = max_delay
+        self.max_suspension_seconds = max_suspension_seconds
+        self._lock = asyncio.Lock()
+        self._next_available_at: float = 0.0
+        self.last_suspension_capped = False
+
+    async def wait_for_turn(self) -> None:
+        """Block until this host's next request may be sent, then reserve it."""
+        async with self._lock:
+            wait_seconds = max(0.0, self._next_available_at - time.monotonic())
+            if wait_seconds > 0:
+                await asyncio.sleep(wait_seconds)
+            self._next_available_at = time.monotonic() + self.min_delay
+
+    def suspend_for_retry_after(self, retry_after_value: str | None) -> float:
+        """Extend this host's suspension from a 429/503 ``Retry-After`` header.
+
+        Returns the number of seconds actually applied, capped at
+        ``max_suspension_seconds``. A missing or unparseable value falls
+        back to exponential-backoff-friendly ``max_delay`` instead of a hang
+        or an unbounded default; ``last_suspension_capped`` tells the caller
+        whether the requested suspension exceeded the cap and pending URLs
+        for this host should be marked ``incomplete`` for this run.
+        """
+        seconds = _parse_retry_after(retry_after_value)
+        if seconds is None:
+            seconds = self.max_delay
+            self.last_suspension_capped = False
+        else:
+            self.last_suspension_capped = seconds > self.max_suspension_seconds
+            seconds = min(seconds, self.max_suspension_seconds)
+        self._next_available_at = max(
+            self._next_available_at,
+            time.monotonic() + seconds,
+        )
+        return seconds
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse Retry-After as delay-seconds or an HTTP-date, per RFC 9110."""
+    if not value:
+        return None
+    stripped = value.strip()
+    try:
+        return max(0.0, float(stripped))
+    except ValueError:
+        pass
+    try:
+        parsed_date = parsedate_to_datetime(stripped)
+    except TypeError, ValueError, OverflowError:
+        return None
+    if parsed_date.tzinfo is None:
+        parsed_date = parsed_date.replace(tzinfo=UTC)
+    return max(0.0, (parsed_date - datetime.now(UTC)).total_seconds())

--- a/crawler/tapio_crawler/discovery/robots.py
+++ b/crawler/tapio_crawler/discovery/robots.py
@@ -1,0 +1,109 @@
+"""Fetch and parse robots.txt with fail-closed semantics for required sources.
+
+Wraps Python's stdlib ``RobotFileParser`` (which itself would fail open on a
+fetch error) so a ``robots_policy: require`` source can tell "no rules found"
+apart from "rules could not be confirmed".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from urllib.parse import urljoin
+from urllib.robotparser import RobotFileParser
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+NOT_FOUND_STATUS = 404
+CLIENT_ERROR_STATUS = 400
+
+
+@dataclass
+class RobotsRules:
+    """Parsed robots.txt rules for one host, or an explicit fetch failure.
+
+    ``reachable`` is ``False`` only when the fetch itself failed (network
+    error, timeout, or a non-2xx/404 response) - not when robots.txt is
+    simply absent, which conventionally means no restrictions.
+    """
+
+    reachable: bool
+    crawl_delay: float | None = None
+    sitemap_urls: list[str] = field(default_factory=list)
+    _parser: RobotFileParser | None = None
+
+    def can_fetch(self, user_agent: str, url: str) -> bool:
+        """Return whether ``user_agent`` may fetch ``url`` under these rules.
+
+        Callers with ``robots_policy: require`` must check ``reachable``
+        first: an unreachable result has no rules to evaluate and must not
+        be treated as an implicit allow.
+        """
+        if self._parser is None:
+            return True
+        return self._parser.can_fetch(user_agent, url)
+
+
+async def fetch_robots_rules(
+    base_url: str,
+    user_agent: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> RobotsRules:
+    """Fetch and parse ``base_url``'s robots.txt.
+
+    A 404 means no restrictions, per convention. Any other failure - a
+    non-2xx/404 status, a timeout, or a connection error - is reported as
+    ``reachable=False``.
+    """
+    robots_url = urljoin(base_url, "/robots.txt")
+    owns_client = client is None
+    http_client = client or httpx.AsyncClient(timeout=timeout)
+    try:
+        response = await http_client.get(robots_url, headers={"User-Agent": user_agent})
+    except httpx.HTTPError:
+        logger.warning("Failed to fetch robots.txt from %s", robots_url)
+        return RobotsRules(reachable=False)
+    finally:
+        if owns_client:
+            await http_client.aclose()
+
+    if response.status_code == NOT_FOUND_STATUS:
+        return RobotsRules(reachable=True)
+    if response.status_code >= CLIENT_ERROR_STATUS:
+        logger.warning(
+            "robots.txt fetch for %s returned HTTP %s",
+            robots_url,
+            response.status_code,
+        )
+        return RobotsRules(reachable=False)
+
+    parser = RobotFileParser()
+    parser.parse(response.text.splitlines())
+    return RobotsRules(
+        reachable=True,
+        crawl_delay=_own_or_wildcard_crawl_delay(parser, user_agent),
+        sitemap_urls=list(parser.site_maps() or []),
+        _parser=parser,
+    )
+
+
+def _own_or_wildcard_crawl_delay(
+    parser: RobotFileParser,
+    user_agent: str,
+) -> float | None:
+    """Prefer a Crawl-delay stanza for our own User-Agent over a wildcard one."""
+    return _safe_crawl_delay(parser, user_agent) or _safe_crawl_delay(parser, "*")
+
+
+def _safe_crawl_delay(parser: RobotFileParser, user_agent: str) -> float | None:
+    """Return a parsed Crawl-delay, ignoring a malformed or missing value."""
+    try:
+        delay = parser.crawl_delay(user_agent)
+        return float(delay) if delay is not None else None
+    except ValueError, TypeError:
+        return None

--- a/crawler/tapio_crawler/discovery/robots.py
+++ b/crawler/tapio_crawler/discovery/robots.py
@@ -14,11 +14,15 @@ from urllib.robotparser import RobotFileParser
 
 import httpx
 
+from tapio_crawler.discovery.rate_limiter import HostRateLimiter
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 10.0
 NOT_FOUND_STATUS = 404
 CLIENT_ERROR_STATUS = 400
+TOO_MANY_REQUESTS_STATUS = 429
+SERVICE_UNAVAILABLE_STATUS = 503
 
 
 @dataclass
@@ -53,16 +57,20 @@ async def fetch_robots_rules(
     *,
     client: httpx.AsyncClient | None = None,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    rate_limiter: HostRateLimiter | None = None,
 ) -> RobotsRules:
     """Fetch and parse ``base_url``'s robots.txt.
 
     A 404 means no restrictions, per convention. Any other failure - a
     non-2xx/404 status, a timeout, or a connection error - is reported as
-    ``reachable=False``.
+    ``reachable=False``. When ``rate_limiter`` is given, this fetch shares
+    that host's politeness delay with every other discovery request.
     """
     robots_url = urljoin(base_url, "/robots.txt")
     owns_client = client is None
     http_client = client or httpx.AsyncClient(timeout=timeout)
+    if rate_limiter is not None:
+        await rate_limiter.wait_for_turn()
     try:
         response = await http_client.get(robots_url, headers={"User-Agent": user_agent})
     except httpx.HTTPError:
@@ -74,6 +82,12 @@ async def fetch_robots_rules(
 
     if response.status_code == NOT_FOUND_STATUS:
         return RobotsRules(reachable=True)
+    if rate_limiter is not None and response.status_code in (
+        TOO_MANY_REQUESTS_STATUS,
+        SERVICE_UNAVAILABLE_STATUS,
+    ):
+        rate_limiter.suspend_for_retry_after(response.headers.get("Retry-After"))
+        return RobotsRules(reachable=False)
     if response.status_code >= CLIENT_ERROR_STATUS:
         logger.warning(
             "robots.txt fetch for %s returned HTTP %s",

--- a/crawler/tapio_crawler/discovery/robots.py
+++ b/crawler/tapio_crawler/discovery/robots.py
@@ -7,6 +7,7 @@ apart from "rules could not be confirmed".
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from urllib.parse import urljoin
@@ -56,7 +57,6 @@ async def fetch_robots_rules(
     user_agent: str,
     *,
     client: httpx.AsyncClient | None = None,
-    timeout: float = DEFAULT_TIMEOUT_SECONDS,
     rate_limiter: HostRateLimiter | None = None,
 ) -> RobotsRules:
     """Fetch and parse ``base_url``'s robots.txt.
@@ -68,12 +68,13 @@ async def fetch_robots_rules(
     """
     robots_url = urljoin(base_url, "/robots.txt")
     owns_client = client is None
-    http_client = client or httpx.AsyncClient(timeout=timeout)
+    http_client = client or httpx.AsyncClient()
     if rate_limiter is not None:
         await rate_limiter.wait_for_turn()
     try:
-        response = await http_client.get(robots_url, headers={"User-Agent": user_agent})
-    except httpx.HTTPError:
+        async with asyncio.timeout(DEFAULT_TIMEOUT_SECONDS):
+            response = await http_client.get(robots_url, headers={"User-Agent": user_agent})
+    except httpx.HTTPError, TimeoutError:
         logger.warning("Failed to fetch robots.txt from %s", robots_url)
         return RobotsRules(reachable=False)
     finally:

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -1,4 +1,6 @@
-"""Dispatches sitemap or gap-crawl discovery for one site and records the
+"""Discovery run orchestration.
+
+Dispatches sitemap or gap-crawl discovery for one site and records the
 resulting URL inventory in the manifest.
 """
 
@@ -35,7 +37,19 @@ _SCOPE_REASON_STATUS: dict[str, ScopeStatus] = {
 
 @dataclass
 class DiscoveryRunSummary:
-    """Counts describing one discovery run, for the run's report/log line."""
+    """Counts describing one discovery run, for the run's report/log line.
+
+    Attributes:
+        run_id: Unique identifier for this discovery run.
+        site_name: Name of the configured source site.
+        discovered: Total number of URLs discovered, before scope filtering.
+        eligible: Number of discovered URLs that are eligible for collection.
+        excluded_by_reason: Count of excluded URLs, keyed by exclusion reason.
+        child_sitemaps_fetched: Number of child sitemaps fetched when the
+            source was a sitemap index.
+        complete: Whether the run finished without a fatal interruption
+            (for example, an unreachable robots.txt or a failed fetch).
+    """
 
     run_id: str
     site_name: str
@@ -54,10 +68,24 @@ class DiscoveryRunner:
     """Runs one discovery pass for a site and upserts results into the manifest."""
 
     def __init__(self, manifest_store: ManifestStore) -> None:
+        """Initialize the runner with the manifest store it persists results to.
+
+        Args:
+            manifest_store: Store used to record discovered URLs.
+        """
         self._manifest_store = manifest_store
 
     async def run(self, site_name: str, site_config: SiteConfig) -> DiscoveryRunSummary:
-        """Discover URLs for ``site_name`` and record them in the manifest."""
+        """Discover URLs for ``site_name`` and record them in the manifest.
+
+        Args:
+            site_name: Name of the configured source site.
+            site_config: Configuration for the site, including its discovery,
+                scope, and politeness settings.
+
+        Returns:
+            A summary of counts and completeness for this run.
+        """
         run_id = str(uuid.uuid4())
         summary = DiscoveryRunSummary(run_id=run_id, site_name=site_name)
         config = site_config.crawler_config
@@ -65,9 +93,7 @@ class DiscoveryRunner:
 
         # Shared across robots, sitemap, and gap-crawl requests to this host so a
         # Crawl-delay floor or Retry-After suspension applies uniformly.
-        rate_limiter = HostRateLimiter(
-            min_delay=config.min_delay, max_delay=config.max_delay
-        )
+        rate_limiter = HostRateLimiter(min_delay=config.min_delay, max_delay=config.max_delay)
         base_url = str(site_config.base_url).rstrip("/")
         robots = await fetch_robots_rules(
             base_url,
@@ -76,17 +102,13 @@ class DiscoveryRunner:
         )
         if not robots.reachable and config.robots_policy == "require":
             summary.complete = False
-            logger.warning(
-                "robots.txt unreachable for %s; marking run incomplete", site_name
-            )
+            logger.warning("robots.txt unreachable for %s; marking run incomplete", site_name)
             return summary
 
         effective_delay = resolve_effective_delay(
             configured_min_delay=config.min_delay,
             configured_max_delay=config.max_delay,
-            crawl_delay=robots.crawl_delay
-            if config.politeness.respect_crawl_delay
-            else None,
+            crawl_delay=robots.crawl_delay if config.politeness.respect_crawl_delay else None,
         )
         rate_limiter.min_delay = effective_delay.min_delay
         rate_limiter.max_delay = effective_delay.max_delay
@@ -159,9 +181,7 @@ class DiscoveryRunner:
                 summary.eligible += 1
             else:
                 reason = decision.reason or "unknown"
-                summary.excluded_by_reason[reason] = (
-                    summary.excluded_by_reason.get(reason, 0) + 1
-                )
+                summary.excluded_by_reason[reason] = summary.excluded_by_reason.get(reason, 0) + 1
 
             record = ManifestRecord(
                 site_name=site_name,
@@ -172,9 +192,7 @@ class DiscoveryRunner:
                 first_seen_at=now,
                 last_seen_at=now,
                 scope_status=(
-                    "eligible"
-                    if decision.eligible
-                    else _SCOPE_REASON_STATUS.get(decision.reason or "", "excluded")
+                    "eligible" if decision.eligible else _SCOPE_REASON_STATUS.get(decision.reason or "", "excluded")
                 ),
                 scope_reason=decision.reason,
             )

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -11,13 +11,13 @@ from datetime import UTC, datetime
 
 import httpx
 
-from tapio_crawler.config.config_models import SiteConfig
+from tapio_crawler.config.config_models import CrawlerConfig, SiteConfig
 from tapio_crawler.discovery.gap_crawl import discover_via_gap_crawl
 from tapio_crawler.discovery.rate_limiter import (
     HostRateLimiter,
     resolve_effective_delay,
 )
-from tapio_crawler.discovery.robots import fetch_robots_rules
+from tapio_crawler.discovery.robots import RobotsRules, fetch_robots_rules
 from tapio_crawler.discovery.scope import evaluate_scope
 from tapio_crawler.discovery.sitemap import discover_sitemap_urls
 from tapio_crawler.manifest.models import DiscoverySource, ManifestRecord, ScopeStatus
@@ -61,16 +61,19 @@ class DiscoveryRunner:
         run_id = str(uuid.uuid4())
         summary = DiscoveryRunSummary(run_id=run_id, site_name=site_name)
         config = site_config.crawler_config
+        _require_discovery_source(site_name, config)
 
-        if config.discovery.source == "none" and not config.gap_crawl.enabled:
-            msg = (
-                f"{site_name}: discovery.source is 'none' but gap_crawl is not "
-                "enabled; the site has no way to discover URLs"
-            )
-            raise MisconfiguredDiscoveryError(msg)
-
+        # Shared across robots, sitemap, and gap-crawl requests to this host so a
+        # Crawl-delay floor or Retry-After suspension applies uniformly.
+        rate_limiter = HostRateLimiter(
+            min_delay=config.min_delay, max_delay=config.max_delay
+        )
         base_url = str(site_config.base_url).rstrip("/")
-        robots = await fetch_robots_rules(base_url, config.politeness.user_agent)
+        robots = await fetch_robots_rules(
+            base_url,
+            config.politeness.user_agent,
+            rate_limiter=rate_limiter,
+        )
         if not robots.reachable and config.robots_policy == "require":
             summary.complete = False
             logger.warning(
@@ -85,13 +88,33 @@ class DiscoveryRunner:
             if config.politeness.respect_crawl_delay
             else None,
         )
-        rate_limiter = HostRateLimiter(
-            min_delay=effective_delay.min_delay,
-            max_delay=effective_delay.max_delay,
-        )
+        rate_limiter.min_delay = effective_delay.min_delay
+        rate_limiter.max_delay = effective_delay.max_delay
 
-        discovered_urls: list[str] = []
-        source_tag: DiscoverySource
+        discovered_urls, lastmod_by_url, source_tag = await self._discover_urls(
+            config,
+            robots,
+            rate_limiter,
+            summary,
+        )
+        self._persist_discovered_urls(
+            site_name,
+            config,
+            discovered_urls,
+            lastmod_by_url,
+            source_tag,
+            summary,
+        )
+        return summary
+
+    async def _discover_urls(
+        self,
+        config: CrawlerConfig,
+        robots: RobotsRules,
+        rate_limiter: HostRateLimiter,
+        summary: DiscoveryRunSummary,
+    ) -> tuple[list[str], dict[str, datetime | None], DiscoverySource]:
+        """Dispatch to sitemap or gap-crawl discovery and update run counts."""
         if config.discovery.source == "sitemap":
             sitemap_urls = config.discovery.sitemap_urls or robots.sitemap_urls
             async with httpx.AsyncClient() as client:
@@ -100,26 +123,34 @@ class DiscoveryRunner:
                     client=client,
                     rate_limiter=rate_limiter,
                     user_agent=config.politeness.user_agent,
+                    allowed_hosts=config.scope.allowed_domains or None,
                 )
-            discovered_urls = [entry.url for entry in sitemap_result.urls]
             summary.child_sitemaps_fetched = sitemap_result.child_sitemaps_fetched
             summary.complete = sitemap_result.complete
+            discovered_urls = [entry.url for entry in sitemap_result.urls]
             lastmod_by_url = {entry.url: entry.lastmod for entry in sitemap_result.urls}
-            source_tag = "sitemap"
-        else:
-            gap_result = await discover_via_gap_crawl(
-                config.gap_crawl,
-                config.scope,
-                user_agent=config.politeness.user_agent,
-                min_delay=effective_delay.min_delay,
-                max_delay=effective_delay.max_delay,
-                max_concurrent=config.max_concurrent,
-            )
-            discovered_urls = gap_result.urls
-            summary.complete = gap_result.complete
-            lastmod_by_url = {}
-            source_tag = "deep_crawl"
+            return discovered_urls, lastmod_by_url, "sitemap"
 
+        gap_result = await discover_via_gap_crawl(
+            config.gap_crawl,
+            config.scope,
+            user_agent=config.politeness.user_agent,
+            rate_limiter=rate_limiter,
+            max_concurrent=config.max_concurrent,
+        )
+        summary.complete = gap_result.complete
+        return gap_result.urls, {}, "deep_crawl"
+
+    def _persist_discovered_urls(
+        self,
+        site_name: str,
+        config: CrawlerConfig,
+        discovered_urls: list[str],
+        lastmod_by_url: dict[str, datetime | None],
+        source_tag: DiscoverySource,
+        summary: DiscoveryRunSummary,
+    ) -> None:
+        """Score every discovered URL against scope and upsert it into the manifest."""
         summary.discovered = len(discovered_urls)
         now = datetime.now(UTC)
         for url in discovered_urls:
@@ -149,4 +180,12 @@ class DiscoveryRunner:
             )
             self._manifest_store.upsert(record)
 
-        return summary
+
+def _require_discovery_source(site_name: str, config: CrawlerConfig) -> None:
+    """Raise if a site has neither sitemap nor gap-crawl discovery configured."""
+    if config.discovery.source == "none" and not config.gap_crawl.enabled:
+        msg = (
+            f"{site_name}: discovery.source is 'none' but gap_crawl is not "
+            "enabled; the site has no way to discover URLs"
+        )
+        raise MisconfiguredDiscoveryError(msg)

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -1,0 +1,152 @@
+"""Dispatches sitemap or gap-crawl discovery for one site and records the
+resulting URL inventory in the manifest.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import httpx
+
+from tapio_crawler.config.config_models import SiteConfig
+from tapio_crawler.discovery.gap_crawl import discover_via_gap_crawl
+from tapio_crawler.discovery.rate_limiter import (
+    HostRateLimiter,
+    resolve_effective_delay,
+)
+from tapio_crawler.discovery.robots import fetch_robots_rules
+from tapio_crawler.discovery.scope import evaluate_scope
+from tapio_crawler.discovery.sitemap import discover_sitemap_urls
+from tapio_crawler.manifest.models import DiscoverySource, ManifestRecord, ScopeStatus
+from tapio_crawler.manifest.normalize import canonicalize_url
+from tapio_crawler.manifest.store import ManifestStore
+
+logger = logging.getLogger(__name__)
+
+_SCOPE_REASON_STATUS: dict[str, ScopeStatus] = {
+    "domain_not_allowed": "out_of_scope",
+    "not_in_include_patterns": "out_of_scope",
+    "excluded_by_pattern": "excluded",
+}
+
+
+@dataclass
+class DiscoveryRunSummary:
+    """Counts describing one discovery run, for the run's report/log line."""
+
+    run_id: str
+    site_name: str
+    discovered: int = 0
+    eligible: int = 0
+    excluded_by_reason: dict[str, int] = field(default_factory=dict)
+    child_sitemaps_fetched: int = 0
+    complete: bool = True
+
+
+class MisconfiguredDiscoveryError(Exception):
+    """Raised when a site has no way to discover URLs at all."""
+
+
+class DiscoveryRunner:
+    """Runs one discovery pass for a site and upserts results into the manifest."""
+
+    def __init__(self, manifest_store: ManifestStore) -> None:
+        self._manifest_store = manifest_store
+
+    async def run(self, site_name: str, site_config: SiteConfig) -> DiscoveryRunSummary:
+        """Discover URLs for ``site_name`` and record them in the manifest."""
+        run_id = str(uuid.uuid4())
+        summary = DiscoveryRunSummary(run_id=run_id, site_name=site_name)
+        config = site_config.crawler_config
+
+        if config.discovery.source == "none" and not config.gap_crawl.enabled:
+            msg = (
+                f"{site_name}: discovery.source is 'none' but gap_crawl is not "
+                "enabled; the site has no way to discover URLs"
+            )
+            raise MisconfiguredDiscoveryError(msg)
+
+        base_url = str(site_config.base_url).rstrip("/")
+        robots = await fetch_robots_rules(base_url, config.politeness.user_agent)
+        if not robots.reachable and config.robots_policy == "require":
+            summary.complete = False
+            logger.warning(
+                "robots.txt unreachable for %s; marking run incomplete", site_name
+            )
+            return summary
+
+        effective_delay = resolve_effective_delay(
+            configured_min_delay=config.min_delay,
+            configured_max_delay=config.max_delay,
+            crawl_delay=robots.crawl_delay
+            if config.politeness.respect_crawl_delay
+            else None,
+        )
+        rate_limiter = HostRateLimiter(
+            min_delay=effective_delay.min_delay,
+            max_delay=effective_delay.max_delay,
+        )
+
+        discovered_urls: list[str] = []
+        source_tag: DiscoverySource
+        if config.discovery.source == "sitemap":
+            sitemap_urls = config.discovery.sitemap_urls or robots.sitemap_urls
+            async with httpx.AsyncClient() as client:
+                sitemap_result = await discover_sitemap_urls(
+                    sitemap_urls,
+                    client=client,
+                    rate_limiter=rate_limiter,
+                    user_agent=config.politeness.user_agent,
+                )
+            discovered_urls = [entry.url for entry in sitemap_result.urls]
+            summary.child_sitemaps_fetched = sitemap_result.child_sitemaps_fetched
+            summary.complete = sitemap_result.complete
+            lastmod_by_url = {entry.url: entry.lastmod for entry in sitemap_result.urls}
+            source_tag = "sitemap"
+        else:
+            gap_result = await discover_via_gap_crawl(
+                config.gap_crawl,
+                config.scope,
+                user_agent=config.politeness.user_agent,
+                min_delay=effective_delay.min_delay,
+                max_delay=effective_delay.max_delay,
+                max_concurrent=config.max_concurrent,
+            )
+            discovered_urls = gap_result.urls
+            summary.complete = gap_result.complete
+            lastmod_by_url = {}
+            source_tag = "deep_crawl"
+
+        summary.discovered = len(discovered_urls)
+        now = datetime.now(UTC)
+        for url in discovered_urls:
+            decision = evaluate_scope(url, config.scope)
+            if decision.eligible:
+                summary.eligible += 1
+            else:
+                reason = decision.reason or "unknown"
+                summary.excluded_by_reason[reason] = (
+                    summary.excluded_by_reason.get(reason, 0) + 1
+                )
+
+            record = ManifestRecord(
+                site_name=site_name,
+                source_url=url,
+                canonical_url=canonicalize_url(url),
+                discovery_source={source_tag},
+                sitemap_lastmod=lastmod_by_url.get(url),
+                first_seen_at=now,
+                last_seen_at=now,
+                scope_status=(
+                    "eligible"
+                    if decision.eligible
+                    else _SCOPE_REASON_STATUS.get(decision.reason or "", "excluded")
+                ),
+                scope_reason=decision.reason,
+            )
+            self._manifest_store.upsert(record)
+
+        return summary

--- a/crawler/tapio_crawler/discovery/scope.py
+++ b/crawler/tapio_crawler/discovery/scope.py
@@ -16,32 +16,39 @@ from tapio_crawler.config.config_models import ScopeConfig
 
 @dataclass
 class ScopeDecision:
-    """Whether one URL is eligible for a source, and why not if not."""
+    """Whether one URL is eligible for a source, and why not if not.
+
+    Attributes:
+        eligible: Whether the URL is in scope for collection.
+        reason: Machine-readable reason code when ``eligible`` is ``False``.
+    """
 
     eligible: bool
     reason: str | None = None
 
 
 def evaluate_scope(url: str, scope: ScopeConfig) -> ScopeDecision:
-    """Return the scope decision for ``url`` under ``scope``'s domain/path rules."""
+    """Return the scope decision for ``url`` under ``scope``'s domain/path rules.
+
+    Args:
+        url: The URL to evaluate.
+        scope: Domain and path scope rules to evaluate ``url`` against.
+
+    Returns:
+        The eligibility decision, with a reason code when ineligible.
+    """
     parts = urlsplit(url)
     host = (parts.hostname or "").lower()
     # Patterns like "/en/*" or "*?*utm_*" are path-relative, not full-URL.
     target = parts.path + (f"?{parts.query}" if parts.query else "")
 
-    if scope.allowed_domains and not any(
-        host == domain.lower() for domain in scope.allowed_domains
-    ):
+    if scope.allowed_domains and not any(host == domain.lower() for domain in scope.allowed_domains):
         return ScopeDecision(eligible=False, reason="domain_not_allowed")
 
-    if scope.exclude_url_patterns and any(
-        fnmatch(target, pattern) for pattern in scope.exclude_url_patterns
-    ):
+    if scope.exclude_url_patterns and any(fnmatch(target, pattern) for pattern in scope.exclude_url_patterns):
         return ScopeDecision(eligible=False, reason="excluded_by_pattern")
 
-    if scope.include_url_patterns and not any(
-        fnmatch(target, pattern) for pattern in scope.include_url_patterns
-    ):
+    if scope.include_url_patterns and not any(fnmatch(target, pattern) for pattern in scope.include_url_patterns):
         return ScopeDecision(eligible=False, reason="not_in_include_patterns")
 
     return ScopeDecision(eligible=True)

--- a/crawler/tapio_crawler/discovery/scope.py
+++ b/crawler/tapio_crawler/discovery/scope.py
@@ -1,0 +1,47 @@
+"""Domain and path scope evaluation for a discovered URL.
+
+Content-type and language eligibility are evaluated at render time (not
+here): a URL's content type is only known after a fetch, and language
+scope is expressed as a path pattern (see ``ScopeConfig.include_url_patterns``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from urllib.parse import urlsplit
+
+from tapio_crawler.config.config_models import ScopeConfig
+
+
+@dataclass
+class ScopeDecision:
+    """Whether one URL is eligible for a source, and why not if not."""
+
+    eligible: bool
+    reason: str | None = None
+
+
+def evaluate_scope(url: str, scope: ScopeConfig) -> ScopeDecision:
+    """Return the scope decision for ``url`` under ``scope``'s domain/path rules."""
+    parts = urlsplit(url)
+    host = (parts.hostname or "").lower()
+    # Patterns like "/en/*" or "*?*utm_*" are path-relative, not full-URL.
+    target = parts.path + (f"?{parts.query}" if parts.query else "")
+
+    if scope.allowed_domains and not any(
+        host == domain.lower() for domain in scope.allowed_domains
+    ):
+        return ScopeDecision(eligible=False, reason="domain_not_allowed")
+
+    if scope.exclude_url_patterns and any(
+        fnmatch(target, pattern) for pattern in scope.exclude_url_patterns
+    ):
+        return ScopeDecision(eligible=False, reason="excluded_by_pattern")
+
+    if scope.include_url_patterns and not any(
+        fnmatch(target, pattern) for pattern in scope.include_url_patterns
+    ):
+        return ScopeDecision(eligible=False, reason="not_in_include_patterns")
+
+    return ScopeDecision(eligible=True)

--- a/crawler/tapio_crawler/discovery/sitemap.py
+++ b/crawler/tapio_crawler/discovery/sitemap.py
@@ -117,9 +117,7 @@ async def discover_sitemap_urls(
 def _is_allowed(url: str, allowed_hosts: set[str]) -> bool:
     """Return whether ``url``'s scheme and host are within ``allowed_hosts``."""
     parts = urlsplit(url)
-    return parts.scheme in _ALLOWED_SCHEMES and (parts.hostname or "").lower() in (
-        allowed_hosts
-    )
+    return parts.scheme in _ALLOWED_SCHEMES and (parts.hostname or "").lower() in (allowed_hosts)
 
 
 async def _fetch_sitemap(
@@ -152,7 +150,9 @@ async def _fetch_sitemap(
 
 def _parse_sitemap(content: bytes) -> tuple[list[str], list[SitemapUrlEntry]]:
     """Return child-sitemap locations and URL entries from one sitemap document."""
-    root = ET.fromstring(content)
+    # Sitemaps are fetched only from operator-configured source hosts, not
+    # arbitrary user input.
+    root = ET.fromstring(content)  # noqa: S314
     _strip_namespaces(root)
 
     child_sitemaps = [
@@ -167,9 +167,7 @@ def _parse_sitemap(content: bytes) -> tuple[list[str], list[SitemapUrlEntry]]:
         SitemapUrlEntry(
             url=loc.text.strip(),
             lastmod=_parse_lastmod(
-                lastmod_elem.text
-                if (lastmod_elem := url_elem.find("lastmod")) is not None
-                else None,
+                lastmod_elem.text if (lastmod_elem := url_elem.find("lastmod")) is not None else None,
             ),
         )
         for url_elem in root.findall(".//url")

--- a/crawler/tapio_crawler/discovery/sitemap.py
+++ b/crawler/tapio_crawler/discovery/sitemap.py
@@ -1,0 +1,169 @@
+"""Sitemap-first URL discovery.
+
+Fetches a source's sitemap(s) directly with the shared rate limiter and
+robots handling, rather than through Crawl4AI's ``AsyncUrlSeeder`` -
+the installed version does not expose a per-URL ``lastmod`` or a
+child-sitemap-fetch count, both of which Requirement 2 needs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from xml.etree import ElementTree as ET
+
+import httpx
+
+from tapio_crawler.discovery.rate_limiter import HostRateLimiter
+
+logger = logging.getLogger(__name__)
+
+TOO_MANY_REQUESTS_STATUS = 429
+SERVICE_UNAVAILABLE_STATUS = 503
+CLIENT_ERROR_STATUS = 400
+
+
+@dataclass
+class SitemapUrlEntry:
+    """One URL discovered from a sitemap, with its raw lastmod if present."""
+
+    url: str
+    lastmod: datetime | None = None
+
+
+@dataclass
+class SitemapDiscoveryResult:
+    """The outcome of fetching and parsing every sitemap for one source."""
+
+    urls: list[SitemapUrlEntry] = field(default_factory=list)
+    child_sitemaps_fetched: int = 0
+    complete: bool = True
+
+
+async def discover_sitemap_urls(
+    sitemap_urls: list[str],
+    *,
+    client: httpx.AsyncClient,
+    rate_limiter: HostRateLimiter,
+    user_agent: str,
+    max_child_sitemaps: int = 10_000,
+) -> SitemapDiscoveryResult:
+    """Fetch every sitemap, following sitemap-index nesting.
+
+    Marks the result ``complete=False`` if any sitemap fails to fetch or
+    parse, or if the child-sitemap cap is reached, so a discovery run does
+    not claim complete source coverage on a partial failure.
+    """
+    result = SitemapDiscoveryResult()
+    if not sitemap_urls:
+        result.complete = False
+        return result
+
+    queue = list(sitemap_urls)
+    seen: set[str] = set()
+
+    while queue:
+        if len(seen) >= max_child_sitemaps:
+            logger.warning("Reached child-sitemap fetch cap of %s", max_child_sitemaps)
+            result.complete = False
+            break
+        sitemap_url = queue.pop(0)
+        if sitemap_url in seen:
+            continue
+        seen.add(sitemap_url)
+
+        content = await _fetch_sitemap(
+            sitemap_url,
+            client=client,
+            rate_limiter=rate_limiter,
+            user_agent=user_agent,
+        )
+        if content is None:
+            result.complete = False
+            continue
+        result.child_sitemaps_fetched += 1
+
+        try:
+            child_sitemaps, urls = _parse_sitemap(content)
+        except ET.ParseError:
+            logger.warning("Failed to parse sitemap %s", sitemap_url)
+            result.complete = False
+            continue
+
+        queue.extend(child_sitemaps)
+        result.urls.extend(urls)
+
+    return result
+
+
+async def _fetch_sitemap(
+    sitemap_url: str,
+    *,
+    client: httpx.AsyncClient,
+    rate_limiter: HostRateLimiter,
+    user_agent: str,
+) -> bytes | None:
+    """Fetch one sitemap document, honoring the shared per-host rate limit."""
+    await rate_limiter.wait_for_turn()
+    try:
+        response = await client.get(sitemap_url, headers={"User-Agent": user_agent})
+    except httpx.HTTPError:
+        logger.warning("Failed to fetch sitemap %s", sitemap_url)
+        return None
+
+    if response.status_code in (TOO_MANY_REQUESTS_STATUS, SERVICE_UNAVAILABLE_STATUS):
+        rate_limiter.suspend_for_retry_after(response.headers.get("Retry-After"))
+        return None
+    if response.status_code >= CLIENT_ERROR_STATUS:
+        logger.warning(
+            "Sitemap fetch for %s returned HTTP %s",
+            sitemap_url,
+            response.status_code,
+        )
+        return None
+    return response.content
+
+
+def _parse_sitemap(content: bytes) -> tuple[list[str], list[SitemapUrlEntry]]:
+    """Return child-sitemap locations and URL entries from one sitemap document."""
+    root = ET.fromstring(content)
+    _strip_namespaces(root)
+
+    child_sitemaps = [
+        loc.text.strip()
+        for sitemap_elem in root.findall(".//sitemap")
+        if (loc := sitemap_elem.find("loc")) is not None and loc.text
+    ]
+    if child_sitemaps:
+        return child_sitemaps, []
+
+    urls = [
+        SitemapUrlEntry(
+            url=loc.text.strip(),
+            lastmod=_parse_lastmod(
+                lastmod_elem.text
+                if (lastmod_elem := url_elem.find("lastmod")) is not None
+                else None,
+            ),
+        )
+        for url_elem in root.findall(".//url")
+        if (loc := url_elem.find("loc")) is not None and loc.text
+    ]
+    return [], urls
+
+
+def _strip_namespaces(root: ET.Element) -> None:
+    """Drop XML namespace prefixes so ``findall`` can use bare tag names."""
+    for elem in root.iter():
+        if "}" in elem.tag:
+            elem.tag = elem.tag.split("}", 1)[1]
+
+
+def _parse_lastmod(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.strip())
+    except ValueError:
+        return None

--- a/crawler/tapio_crawler/discovery/sitemap.py
+++ b/crawler/tapio_crawler/discovery/sitemap.py
@@ -57,16 +57,23 @@ async def discover_sitemap_urls(
     Marks the result ``complete=False`` if any sitemap fails to fetch or
     parse, or if the child-sitemap cap is reached, so a discovery run does
     not claim complete source coverage on a partial failure.
-    ``allowed_hosts``, if given, rejects any sitemap URL - including a
-    child <loc> found by parsing an index - outside the source's scope,
-    since a remote sitemap document is not a trusted URL source.
+    Every sitemap URL - including a child <loc> found by parsing an index -
+    is rejected if it falls outside ``allowed_hosts``, or outside the
+    top-level ``sitemap_urls``' own hosts when ``allowed_hosts`` isn't
+    given, since a remote sitemap document is not a trusted URL source.
     """
     result = SitemapDiscoveryResult()
     if not sitemap_urls:
         result.complete = False
         return result
 
-    allowed = {host.lower() for host in allowed_hosts} if allowed_hosts else None
+    # Falling back to the configured source hosts (rather than no restriction at
+    # all) stops a malicious child <loc> from redirecting discovery off-scope.
+    allowed = (
+        {host.lower() for host in allowed_hosts}
+        if allowed_hosts
+        else {(urlsplit(url).hostname or "").lower() for url in sitemap_urls}
+    )
     top_level = set(sitemap_urls)
     queue = list(sitemap_urls)
     seen: set[str] = set()
@@ -76,7 +83,7 @@ async def discover_sitemap_urls(
         sitemap_url = queue.pop(0)
         if sitemap_url in seen:
             continue
-        if allowed is not None and not _is_allowed(sitemap_url, allowed):
+        if not _is_allowed(sitemap_url, allowed):
             logger.warning("Skipping out-of-scope sitemap URL %s", sitemap_url)
             result.complete = False
             continue
@@ -87,31 +94,49 @@ async def discover_sitemap_urls(
             result.complete = False
             break
         seen.add(sitemap_url)
+        if is_child:
+            child_fetch_count += 1
 
-        content = await _fetch_sitemap(
+        fetched = await _fetch_and_parse_sitemap(
             sitemap_url,
             client=client,
             rate_limiter=rate_limiter,
             user_agent=user_agent,
         )
-        if content is None:
+        if fetched is None:
             result.complete = False
             continue
         if is_child:
-            child_fetch_count += 1
             result.child_sitemaps_fetched += 1
 
-        try:
-            child_sitemaps, urls = _parse_sitemap(content)
-        except ET.ParseError:
-            logger.warning("Failed to parse sitemap %s", sitemap_url)
-            result.complete = False
-            continue
-
+        child_sitemaps, urls = fetched
         queue.extend(child_sitemaps)
         result.urls.extend(urls)
 
     return result
+
+
+async def _fetch_and_parse_sitemap(
+    sitemap_url: str,
+    *,
+    client: httpx.AsyncClient,
+    rate_limiter: HostRateLimiter,
+    user_agent: str,
+) -> tuple[list[str], list[SitemapUrlEntry]] | None:
+    """Fetch and parse one sitemap, or return ``None`` on fetch or parse failure."""
+    content = await _fetch_sitemap(
+        sitemap_url,
+        client=client,
+        rate_limiter=rate_limiter,
+        user_agent=user_agent,
+    )
+    if content is None:
+        return None
+    try:
+        return _parse_sitemap(content)
+    except ET.ParseError:
+        logger.warning("Failed to parse sitemap %s", sitemap_url)
+        return None
 
 
 def _is_allowed(url: str, allowed_hosts: set[str]) -> bool:
@@ -163,17 +188,18 @@ def _parse_sitemap(content: bytes) -> tuple[list[str], list[SitemapUrlEntry]]:
     if child_sitemaps:
         return child_sitemaps, []
 
-    urls = [
-        SitemapUrlEntry(
-            url=loc.text.strip(),
-            lastmod=_parse_lastmod(
-                lastmod_elem.text if (lastmod_elem := url_elem.find("lastmod")) is not None else None,
-            ),
-        )
-        for url_elem in root.findall(".//url")
-        if (loc := url_elem.find("loc")) is not None and loc.text
-    ]
-    return [], urls
+    urls = [_parse_url_entry(url_elem) for url_elem in root.findall(".//url")]
+    return [], [entry for entry in urls if entry is not None]
+
+
+def _parse_url_entry(url_elem: ET.Element) -> SitemapUrlEntry | None:
+    """Return one ``<url>`` element's entry, or ``None`` if it has no ``<loc>``."""
+    loc = url_elem.find("loc")
+    if loc is None or not loc.text:
+        return None
+    lastmod_elem = url_elem.find("lastmod")
+    lastmod_text = lastmod_elem.text if lastmod_elem is not None else None
+    return SitemapUrlEntry(url=loc.text.strip(), lastmod=_parse_lastmod(lastmod_text))
 
 
 def _strip_namespaces(root: ET.Element) -> None:

--- a/crawler/tapio_crawler/discovery/sitemap.py
+++ b/crawler/tapio_crawler/discovery/sitemap.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
+from urllib.parse import urlsplit
 from xml.etree import ElementTree as ET
 
 import httpx
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 TOO_MANY_REQUESTS_STATUS = 429
 SERVICE_UNAVAILABLE_STATUS = 503
 CLIENT_ERROR_STATUS = 400
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 
 @dataclass
@@ -47,6 +49,7 @@ async def discover_sitemap_urls(
     client: httpx.AsyncClient,
     rate_limiter: HostRateLimiter,
     user_agent: str,
+    allowed_hosts: list[str] | None = None,
     max_child_sitemaps: int = 10_000,
 ) -> SitemapDiscoveryResult:
     """Fetch every sitemap, following sitemap-index nesting.
@@ -54,23 +57,35 @@ async def discover_sitemap_urls(
     Marks the result ``complete=False`` if any sitemap fails to fetch or
     parse, or if the child-sitemap cap is reached, so a discovery run does
     not claim complete source coverage on a partial failure.
+    ``allowed_hosts``, if given, rejects any sitemap URL - including a
+    child <loc> found by parsing an index - outside the source's scope,
+    since a remote sitemap document is not a trusted URL source.
     """
     result = SitemapDiscoveryResult()
     if not sitemap_urls:
         result.complete = False
         return result
 
+    allowed = {host.lower() for host in allowed_hosts} if allowed_hosts else None
+    top_level = set(sitemap_urls)
     queue = list(sitemap_urls)
     seen: set[str] = set()
+    child_fetch_count = 0
 
     while queue:
-        if len(seen) >= max_child_sitemaps:
-            logger.warning("Reached child-sitemap fetch cap of %s", max_child_sitemaps)
-            result.complete = False
-            break
         sitemap_url = queue.pop(0)
         if sitemap_url in seen:
             continue
+        if allowed is not None and not _is_allowed(sitemap_url, allowed):
+            logger.warning("Skipping out-of-scope sitemap URL %s", sitemap_url)
+            result.complete = False
+            continue
+
+        is_child = sitemap_url not in top_level
+        if is_child and child_fetch_count >= max_child_sitemaps:
+            logger.warning("Reached child-sitemap fetch cap of %s", max_child_sitemaps)
+            result.complete = False
+            break
         seen.add(sitemap_url)
 
         content = await _fetch_sitemap(
@@ -82,7 +97,9 @@ async def discover_sitemap_urls(
         if content is None:
             result.complete = False
             continue
-        result.child_sitemaps_fetched += 1
+        if is_child:
+            child_fetch_count += 1
+            result.child_sitemaps_fetched += 1
 
         try:
             child_sitemaps, urls = _parse_sitemap(content)
@@ -95,6 +112,14 @@ async def discover_sitemap_urls(
         result.urls.extend(urls)
 
     return result
+
+
+def _is_allowed(url: str, allowed_hosts: set[str]) -> bool:
+    """Return whether ``url``'s scheme and host are within ``allowed_hosts``."""
+    parts = urlsplit(url)
+    return parts.scheme in _ALLOWED_SCHEMES and (parts.hostname or "").lower() in (
+        allowed_hosts
+    )
 
 
 async def _fetch_sitemap(

--- a/crawler/tapio_crawler/manifest/__init__.py
+++ b/crawler/tapio_crawler/manifest/__init__.py
@@ -1,0 +1,1 @@
+"""URL manifest: durable per-URL inventory and collection state."""

--- a/crawler/tapio_crawler/manifest/models.py
+++ b/crawler/tapio_crawler/manifest/models.py
@@ -1,0 +1,50 @@
+"""URL manifest record schema.
+
+See docs/specs/crawler-improvements.md, "URL manifest". Fields owned by
+later phases (rendering, cache/refresh policy) default to ``None`` until
+Phase 2 populates them; discovery only writes the fields it owns.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ScopeStatus = Literal[
+    "eligible",
+    "blocked_robots",
+    "out_of_scope",
+    "excluded",
+    "unsupported_content_type",
+]
+
+DiscoverySource = Literal["sitemap", "deep_crawl", "operator"]
+
+
+class ManifestRecord(BaseModel):
+    """One canonical source URL and its discovery/collection state."""
+
+    site_name: str
+    source_url: str
+    canonical_url: str
+    # Accumulates every mechanism that has found this URL; never overwritten.
+    discovery_source: set[DiscoverySource] = Field(default_factory=set)
+    sitemap_lastmod: datetime | None = None
+    first_seen_at: datetime
+    last_seen_at: datetime
+    scope_status: ScopeStatus
+    scope_reason: str | None = None
+    fetch_status: str | None = None
+    last_attempt_at: datetime | None = None
+    retry_after: datetime | None = None
+    content_hash: str | None = None
+    content_length: int | None = None
+    title: str | None = None
+    language: str | None = None
+    last_rendered_at: datetime | None = None
+    last_ingested_at: datetime | None = None
+    extractor_version: str | None = None
+    cache_status: str | None = None
+    validation_status: str | None = None

--- a/crawler/tapio_crawler/manifest/models.py
+++ b/crawler/tapio_crawler/manifest/models.py
@@ -24,7 +24,36 @@ DiscoverySource = Literal["sitemap", "deep_crawl", "operator"]
 
 
 class ManifestRecord(BaseModel):
-    """One canonical source URL and its discovery/collection state."""
+    """One canonical source URL and its discovery/collection state.
+
+    Attributes:
+        site_name: Name of the configured source site.
+        source_url: The URL as originally discovered, before canonicalization.
+        canonical_url: Canonicalized form of ``source_url``; part of the
+            record's identity together with ``site_name``.
+        discovery_source: Every discovery mechanism that has found this URL;
+            accumulates over time and is never overwritten.
+        sitemap_lastmod: ``<lastmod>`` value from the sitemap, if supplied.
+        first_seen_at: Timestamp when this URL was first discovered.
+        last_seen_at: Timestamp of the most recent discovery run that saw
+            this URL.
+        scope_status: Whether the URL is eligible for collection, and if
+            not, the category of exclusion.
+        scope_reason: Machine-readable reason code backing ``scope_status``.
+        fetch_status: Outcome of the most recent fetch attempt, if any.
+        last_attempt_at: Timestamp of the most recent fetch attempt.
+        retry_after: Earliest time a failed fetch should be retried.
+        content_hash: Hash of the fetched content, used to detect changes.
+        content_length: Byte length of the fetched content.
+        title: Page title extracted from the fetched content.
+        language: Detected or configured language of the content.
+        last_rendered_at: Timestamp of the most recent rendering pass.
+        last_ingested_at: Timestamp of the most recent ingestion into the
+            vector store.
+        extractor_version: Version identifier of the content extractor used.
+        cache_status: Outcome of cache validation for the most recent fetch.
+        validation_status: Outcome of content validation checks.
+    """
 
     site_name: str
     source_url: str

--- a/crawler/tapio_crawler/manifest/normalize.py
+++ b/crawler/tapio_crawler/manifest/normalize.py
@@ -22,6 +22,12 @@ def canonicalize_url(url: str) -> str:
 
     Lowercases scheme and host, strips a default port, drops the fragment,
     and removes known tracking query parameters.
+
+    Args:
+        url: The URL to canonicalize.
+
+    Returns:
+        The canonicalized URL.
     """
     parts = urlsplit(url)
     scheme = parts.scheme.lower()
@@ -32,9 +38,7 @@ def canonicalize_url(url: str) -> str:
         netloc = f"{netloc}:{port}"
 
     query_pairs = [
-        (key, value)
-        for key, value in parse_qsl(parts.query, keep_blank_values=True)
-        if not _is_tracking_param(key)
+        (key, value) for key, value in parse_qsl(parts.query, keep_blank_values=True) if not _is_tracking_param(key)
     ]
     query = urlencode(query_pairs)
     path = parts.path or "/"
@@ -42,6 +46,14 @@ def canonicalize_url(url: str) -> str:
 
 
 def _is_tracking_param(key: str) -> bool:
+    """Report whether ``key`` is a known tracking query parameter.
+
+    Args:
+        key: The query parameter name to check.
+
+    Returns:
+        ``True`` if ``key`` matches a known tracking parameter name or prefix.
+    """
     lowered = key.lower()
     return lowered in _TRACKING_PARAM_NAMES or lowered.startswith(
         _TRACKING_PARAM_PREFIXES,

--- a/crawler/tapio_crawler/manifest/normalize.py
+++ b/crawler/tapio_crawler/manifest/normalize.py
@@ -27,9 +27,9 @@ def canonicalize_url(url: str) -> str:
     scheme = parts.scheme.lower()
     hostname = (parts.hostname or "").lower()
     port = parts.port
-    netloc = hostname
+    netloc = f"[{hostname}]" if ":" in hostname else hostname
     if port is not None and port != _DEFAULT_PORTS.get(scheme):
-        netloc = f"{hostname}:{port}"
+        netloc = f"{netloc}:{port}"
 
     query_pairs = [
         (key, value)

--- a/crawler/tapio_crawler/manifest/normalize.py
+++ b/crawler/tapio_crawler/manifest/normalize.py
@@ -1,0 +1,48 @@
+"""Canonical URL derivation for manifest identity.
+
+Which query parameters are meaningful versus tracking-only is an explicit
+open question per docs/specs/crawler-improvements.md ("begin conservatively
+and add reviewed exceptions"); this strips a small, conservative built-in
+set of well-known tracking parameters rather than trying to infer stripping
+rules from each source's URL-scope glob patterns.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+_TRACKING_PARAM_PREFIXES = ("utm_", "mc_")
+_TRACKING_PARAM_NAMES = frozenset({"gclid", "fbclid", "msclkid", "_ga", "ref"})
+
+
+def canonicalize_url(url: str) -> str:
+    """Derive a stable, deduplicated canonical form of ``url``.
+
+    Lowercases scheme and host, strips a default port, drops the fragment,
+    and removes known tracking query parameters.
+    """
+    parts = urlsplit(url)
+    scheme = parts.scheme.lower()
+    hostname = (parts.hostname or "").lower()
+    port = parts.port
+    netloc = hostname
+    if port is not None and port != _DEFAULT_PORTS.get(scheme):
+        netloc = f"{hostname}:{port}"
+
+    query_pairs = [
+        (key, value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+        if not _is_tracking_param(key)
+    ]
+    query = urlencode(query_pairs)
+    path = parts.path or "/"
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+def _is_tracking_param(key: str) -> bool:
+    lowered = key.lower()
+    return lowered in _TRACKING_PARAM_NAMES or lowered.startswith(
+        _TRACKING_PARAM_PREFIXES,
+    )

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -75,7 +75,7 @@ class ManifestStore:
                     | record.discovery_source,
                     "sitemap_lastmod": record.sitemap_lastmod
                     or existing.sitemap_lastmod,
-                    "last_seen_at": record.last_seen_at,
+                    "last_seen_at": max(record.last_seen_at, existing.last_seen_at),
                     "scope_status": record.scope_status,
                     "scope_reason": record.scope_reason,
                 },

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -48,9 +48,19 @@ CREATE TABLE IF NOT EXISTS manifest (
 
 
 class ManifestStore:
-    """Durable, queryable inventory of every discovered source URL."""
+    """Durable, queryable inventory of every discovered source URL.
+
+    Attributes:
+        path: Filesystem path to the SQLite database backing this store.
+    """
 
     def __init__(self, path: str | Path | None = None) -> None:
+        """Open (creating if needed) the manifest database at ``path``.
+
+        Args:
+            path: Location of the SQLite database file. Defaults to
+                ``DEFAULT_MANIFEST_PATH`` when omitted.
+        """
         self.path = Path(path) if path is not None else Path(DEFAULT_MANIFEST_PATH)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(self.path)
@@ -63,7 +73,17 @@ class ManifestStore:
         self._connection.close()
 
     def upsert(self, record: ManifestRecord) -> ManifestRecord:
-        """Insert or merge ``record`` by its ``(site_name, canonical_url)`` identity."""
+        """Insert or merge ``record`` by its ``(site_name, canonical_url)`` identity.
+
+        Args:
+            record: The candidate record to persist. If a record already
+                exists for the same identity, discovery provenance and
+                ``last_seen_at``/``sitemap_lastmod`` are merged into it
+                rather than overwriting it outright.
+
+        Returns:
+            The record as persisted, after any merge with an existing row.
+        """
         existing = self.get(record.site_name, record.canonical_url)
         merged = (
             record
@@ -71,10 +91,8 @@ class ManifestStore:
             else existing.model_copy(
                 update={
                     "source_url": record.source_url,
-                    "discovery_source": existing.discovery_source
-                    | record.discovery_source,
-                    "sitemap_lastmod": record.sitemap_lastmod
-                    or existing.sitemap_lastmod,
+                    "discovery_source": existing.discovery_source | record.discovery_source,
+                    "sitemap_lastmod": record.sitemap_lastmod or existing.sitemap_lastmod,
                     "last_seen_at": max(record.last_seen_at, existing.last_seen_at),
                     "scope_status": record.scope_status,
                     "scope_reason": record.scope_reason,
@@ -85,7 +103,15 @@ class ManifestStore:
         return merged
 
     def get(self, site_name: str, canonical_url: str) -> ManifestRecord | None:
-        """Return the manifest record for one canonical identity, if present."""
+        """Return the manifest record for one canonical identity, if present.
+
+        Args:
+            site_name: Name of the configured source site.
+            canonical_url: Canonicalized URL identifying the record.
+
+        Returns:
+            The matching record, or ``None`` if no row exists for the identity.
+        """
         row = self._connection.execute(
             "SELECT * FROM manifest WHERE site_name = ? AND canonical_url = ?",
             (site_name, canonical_url),
@@ -98,7 +124,16 @@ class ManifestStore:
         *,
         scope_status: str | None = None,
     ) -> list[ManifestRecord]:
-        """Return every manifest record for one site, optionally filtered."""
+        """Return every manifest record for one site, optionally filtered.
+
+        Args:
+            site_name: Name of the configured source site.
+            scope_status: When given, only return records with this
+                ``scope_status`` value.
+
+        Returns:
+            The matching records, in no particular order.
+        """
         query = "SELECT * FROM manifest WHERE site_name = ?"
         params: list[object] = [site_name]
         if scope_status is not None:
@@ -108,16 +143,21 @@ class ManifestStore:
         return [_row_to_record(row) for row in rows]
 
     def _write(self, record: ManifestRecord) -> None:
+        """Upsert ``record``'s row into the ``manifest`` table.
+
+        Args:
+            record: The record to write, already merged with any existing row.
+        """
         values = _record_to_row(record)
         column_names = ", ".join(_COLUMNS)
         placeholders = ", ".join("?" for _ in _COLUMNS)
         update_clause = ", ".join(
-            f"{name} = excluded.{name}"
-            for name in _COLUMNS
-            if name not in {"site_name", "canonical_url"}
+            f"{name} = excluded.{name}" for name in _COLUMNS if name not in {"site_name", "canonical_url"}
         )
+        # Column names are drawn from the fixed _COLUMNS tuple, never from
+        # user input, so this isn't a SQL-injection vector.
         self._connection.execute(
-            f"INSERT INTO manifest ({column_names}) VALUES ({placeholders}) "
+            f"INSERT INTO manifest ({column_names}) VALUES ({placeholders}) "  # noqa: S608
             f"ON CONFLICT (site_name, canonical_url) DO UPDATE SET {update_clause}",
             [values[name] for name in _COLUMNS],
         )
@@ -125,12 +165,28 @@ class ManifestStore:
 
 
 def _record_to_row(record: ManifestRecord) -> dict[str, Any]:
+    """Serialize ``record`` into a JSON-compatible column-name-keyed mapping.
+
+    Args:
+        record: The record to serialize.
+
+    Returns:
+        A mapping from column name to its SQLite-storable value.
+    """
     data = record.model_dump(mode="json")
     data["discovery_source"] = json.dumps(sorted(record.discovery_source))
     return data
 
 
 def _row_to_record(row: sqlite3.Row) -> ManifestRecord:
+    """Deserialize one ``manifest`` table row into a ``ManifestRecord``.
+
+    Args:
+        row: The raw SQLite row to deserialize.
+
+    Returns:
+        The reconstructed record.
+    """
     data = dict(row)
     data["discovery_source"] = set(json.loads(data["discovery_source"] or "[]"))
     for field_name in (

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -1,0 +1,147 @@
+"""SQLite-backed URL manifest store.
+
+URL identity is ``(site_name, canonical_url)``: upserting merges discovery
+provenance and advances ``last_seen_at`` rather than creating a duplicate row.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from tapio_crawler.config.settings import DEFAULT_MANIFEST_PATH
+from tapio_crawler.manifest.models import ManifestRecord
+
+_COLUMNS = (
+    "site_name",
+    "canonical_url",
+    "source_url",
+    "discovery_source",
+    "sitemap_lastmod",
+    "first_seen_at",
+    "last_seen_at",
+    "scope_status",
+    "scope_reason",
+    "fetch_status",
+    "last_attempt_at",
+    "retry_after",
+    "content_hash",
+    "content_length",
+    "title",
+    "language",
+    "last_rendered_at",
+    "last_ingested_at",
+    "extractor_version",
+    "cache_status",
+    "validation_status",
+)
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS manifest (
+    {", ".join(f"{name} TEXT" if name != "content_length" else f"{name} INTEGER" for name in _COLUMNS)},
+    PRIMARY KEY (site_name, canonical_url)
+);
+"""
+
+
+class ManifestStore:
+    """Durable, queryable inventory of every discovered source URL."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else Path(DEFAULT_MANIFEST_PATH)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(self.path)
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute(_SCHEMA)
+        self._connection.commit()
+
+    def close(self) -> None:
+        """Release the underlying SQLite connection."""
+        self._connection.close()
+
+    def upsert(self, record: ManifestRecord) -> ManifestRecord:
+        """Insert or merge ``record`` by its ``(site_name, canonical_url)`` identity."""
+        existing = self.get(record.site_name, record.canonical_url)
+        merged = (
+            record
+            if existing is None
+            else existing.model_copy(
+                update={
+                    "source_url": record.source_url,
+                    "discovery_source": existing.discovery_source
+                    | record.discovery_source,
+                    "sitemap_lastmod": record.sitemap_lastmod
+                    or existing.sitemap_lastmod,
+                    "last_seen_at": record.last_seen_at,
+                    "scope_status": record.scope_status,
+                    "scope_reason": record.scope_reason,
+                },
+            )
+        )
+        self._write(merged)
+        return merged
+
+    def get(self, site_name: str, canonical_url: str) -> ManifestRecord | None:
+        """Return the manifest record for one canonical identity, if present."""
+        row = self._connection.execute(
+            "SELECT * FROM manifest WHERE site_name = ? AND canonical_url = ?",
+            (site_name, canonical_url),
+        ).fetchone()
+        return None if row is None else _row_to_record(row)
+
+    def list_by_site(
+        self,
+        site_name: str,
+        *,
+        scope_status: str | None = None,
+    ) -> list[ManifestRecord]:
+        """Return every manifest record for one site, optionally filtered."""
+        query = "SELECT * FROM manifest WHERE site_name = ?"
+        params: list[object] = [site_name]
+        if scope_status is not None:
+            query += " AND scope_status = ?"
+            params.append(scope_status)
+        rows = self._connection.execute(query, params).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def _write(self, record: ManifestRecord) -> None:
+        values = _record_to_row(record)
+        column_names = ", ".join(_COLUMNS)
+        placeholders = ", ".join("?" for _ in _COLUMNS)
+        update_clause = ", ".join(
+            f"{name} = excluded.{name}"
+            for name in _COLUMNS
+            if name not in {"site_name", "canonical_url"}
+        )
+        self._connection.execute(
+            f"INSERT INTO manifest ({column_names}) VALUES ({placeholders}) "
+            f"ON CONFLICT (site_name, canonical_url) DO UPDATE SET {update_clause}",
+            [values[name] for name in _COLUMNS],
+        )
+        self._connection.commit()
+
+
+def _record_to_row(record: ManifestRecord) -> dict[str, Any]:
+    data = record.model_dump(mode="json")
+    data["discovery_source"] = json.dumps(sorted(record.discovery_source))
+    return data
+
+
+def _row_to_record(row: sqlite3.Row) -> ManifestRecord:
+    data = dict(row)
+    data["discovery_source"] = set(json.loads(data["discovery_source"] or "[]"))
+    for field_name in (
+        "sitemap_lastmod",
+        "first_seen_at",
+        "last_seen_at",
+        "last_attempt_at",
+        "retry_after",
+        "last_rendered_at",
+        "last_ingested_at",
+    ):
+        if data.get(field_name):
+            data[field_name] = datetime.fromisoformat(data[field_name])
+    return ManifestRecord.model_validate(data)

--- a/crawler/tests/config/test_config_manager.py
+++ b/crawler/tests/config/test_config_manager.py
@@ -1,12 +1,14 @@
 """Tests for loading Crawl4AI site configuration."""
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
 from tapio_crawler.config import ConfigManager
 
 
-def test_config_manager_loads_crawl4ai_config(tmp_path) -> None:
+def test_config_manager_loads_crawl4ai_config(tmp_path: Path) -> None:
     path = tmp_path / "sites.yaml"
     path.write_text(
         """sites:
@@ -29,7 +31,7 @@ def test_config_manager_loads_crawl4ai_config(tmp_path) -> None:
     assert manager.get_site_descriptions() == {"example": "Example site"}
 
 
-def test_config_manager_rejects_missing_base_url(tmp_path) -> None:
+def test_config_manager_rejects_missing_base_url(tmp_path: Path) -> None:
     path = tmp_path / "invalid.yaml"
     path.write_text("sites:\n  example: {}\n", encoding="utf-8")
 
@@ -37,7 +39,7 @@ def test_config_manager_rejects_missing_base_url(tmp_path) -> None:
         ConfigManager.from_file(str(path))
 
 
-def test_config_manager_rejects_empty_configuration(tmp_path) -> None:
+def test_config_manager_rejects_empty_configuration(tmp_path: Path) -> None:
     path = tmp_path / "empty.yaml"
     path.write_text("", encoding="utf-8")
 

--- a/crawler/tests/config/test_config_models.py
+++ b/crawler/tests/config/test_config_models.py
@@ -29,7 +29,6 @@ def test_crawler_config_has_safe_defaults() -> None:
     assert "TapioBot" in config.politeness.user_agent
     assert isinstance(config.discovery, DiscoveryConfig)
     assert config.discovery.source == "none"
-    assert config.discovery.trust_lastmod is False
     assert isinstance(config.scope, ScopeConfig)
     assert config.scope.allowed_content_types == ["text/html"]
     assert isinstance(config.gap_crawl, GapCrawlConfig)

--- a/crawler/tests/config/test_config_models.py
+++ b/crawler/tests/config/test_config_models.py
@@ -47,7 +47,7 @@ def test_crawler_config_allows_sitemap_discovery_without_gap_crawl() -> None:
 
 
 @pytest.mark.parametrize(
-    "field,value",
+    ("field", "value"),
     [("max_depth", -1), ("max_pages", 0), ("max_concurrent", 0)],
 )
 def test_crawler_config_enforces_bounds(field: str, value: int) -> None:

--- a/crawler/tests/config/test_config_models.py
+++ b/crawler/tests/config/test_config_models.py
@@ -5,7 +5,11 @@ from pydantic import HttpUrl, ValidationError
 
 from tapio_crawler.config.config_models import (
     CrawlerConfig,
+    DiscoveryConfig,
+    GapCrawlConfig,
     MarkdownConfig,
+    PolitenessConfig,
+    ScopeConfig,
     SiteConfig,
     SiteConfigRegistry,
 )
@@ -19,11 +23,28 @@ def test_crawler_config_has_safe_defaults() -> None:
     assert config.page_timeout == 30
     assert (config.min_delay, config.max_delay) == (1.0, 3.0)
     assert config.max_concurrent == 3
+    assert config.robots_policy == "require"
+    assert isinstance(config.politeness, PolitenessConfig)
+    assert config.politeness.respect_crawl_delay is True
+    assert "TapioBot" in config.politeness.user_agent
+    assert isinstance(config.discovery, DiscoveryConfig)
+    assert config.discovery.source == "none"
+    assert config.discovery.trust_lastmod is False
+    assert isinstance(config.scope, ScopeConfig)
+    assert config.scope.allowed_content_types == ["text/html"]
+    assert isinstance(config.gap_crawl, GapCrawlConfig)
+    assert config.gap_crawl.enabled is False
 
 
 def test_crawler_config_rejects_invalid_delay_range() -> None:
     with pytest.raises(ValidationError, match="min_delay"):
         CrawlerConfig(min_delay=3.0, max_delay=1.0)
+
+
+def test_crawler_config_allows_sitemap_discovery_without_gap_crawl() -> None:
+    config = CrawlerConfig(discovery={"source": "sitemap"})
+
+    assert config.gap_crawl.enabled is False
 
 
 @pytest.mark.parametrize(

--- a/crawler/tests/conftest.py
+++ b/crawler/tests/conftest.py
@@ -1,13 +1,10 @@
 """Crawler test fixtures."""
 
-import sys
 from pathlib import Path
 
 import pytest
 
 from tapio_crawler.config import ConfigManager
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 @pytest.fixture

--- a/crawler/tests/conftest.py
+++ b/crawler/tests/conftest.py
@@ -5,14 +5,14 @@ from pathlib import Path
 
 import pytest
 
+from tapio_crawler.config import ConfigManager
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 @pytest.fixture
-def test_config_manager(tmp_path):
+def test_config_manager(tmp_path: Path) -> ConfigManager:
     """A Crawl4AI site configuration isolated from repository output."""
-    from tapio_crawler.config import ConfigManager
-
     config_path = tmp_path / "sites.yaml"
     config_path.write_text(
         """sites:

--- a/crawler/tests/crawler/test_crawler.py
+++ b/crawler/tests/crawler/test_crawler.py
@@ -106,9 +106,7 @@ def test_markdown_uses_cached_raw_markdown_when_filtered_value_is_empty() -> Non
         markdown=CachedMarkdown("Cached document content"),
     )
 
-    assert Crawl4AICrawler._markdown(raw_result_with_cached_markdown) == (
-        "Cached document content"
-    )
+    assert Crawl4AICrawler._markdown(raw_result_with_cached_markdown) == ("Cached document content")
 
 
 @pytest.mark.asyncio
@@ -145,9 +143,7 @@ async def test_crawl_skips_site_within_recrawl_interval(tmp_path, monkeypatch) -
     crawler.state_path.write_text(
         json.dumps(
             {
-                "last_successful_crawl_at": (
-                    datetime.now(UTC) - timedelta(hours=1)
-                ).isoformat(),
+                "last_successful_crawl_at": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
             },
         ),
         encoding="utf-8",

--- a/crawler/tests/crawler/test_crawler.py
+++ b/crawler/tests/crawler/test_crawler.py
@@ -15,7 +15,7 @@ from tapio_crawler.config.config_models import CrawlerConfig, SiteConfig
 from tapio_crawler.crawler.crawler import Crawl4AICrawler
 
 
-def site_config(**overrides) -> SiteConfig:
+def site_config(**overrides: object) -> SiteConfig:
     return SiteConfig(
         base_url=HttpUrl("https://example.com"),
         crawler_config=CrawlerConfig(max_depth=0, max_pages=1, **overrides),
@@ -47,8 +47,8 @@ class CachedMarkdown:
 
 
 def test_run_config_uses_content_filtering_and_bounded_bfs(
-    tmp_path,
-    monkeypatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler(
@@ -110,7 +110,7 @@ def test_markdown_uses_cached_raw_markdown_when_filtered_value_is_empty() -> Non
 
 
 @pytest.mark.asyncio
-async def test_crawl_writes_frontmatter_markdown(tmp_path, monkeypatch) -> None:
+async def test_crawl_writes_frontmatter_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler("example", site_config())
     browser = MagicMock()
@@ -137,7 +137,7 @@ async def test_crawl_writes_frontmatter_markdown(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_crawl_skips_site_within_recrawl_interval(tmp_path, monkeypatch) -> None:
+async def test_crawl_skips_site_within_recrawl_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler("example", site_config(recrawl_interval_hours=720))
     crawler.state_path.write_text(
@@ -157,7 +157,7 @@ async def test_crawl_skips_site_within_recrawl_interval(tmp_path, monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_force_crawl_ignores_recrawl_interval(tmp_path, monkeypatch) -> None:
+async def test_force_crawl_ignores_recrawl_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler("example", site_config())
     crawler.state_path.write_text(
@@ -178,8 +178,8 @@ async def test_force_crawl_ignores_recrawl_interval(tmp_path, monkeypatch) -> No
 
 @pytest.mark.asyncio
 async def test_crawl_rejects_failed_and_near_empty_results(
-    tmp_path,
-    monkeypatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler("example", site_config())
@@ -201,8 +201,8 @@ async def test_crawl_rejects_failed_and_near_empty_results(
 
 @pytest.mark.asyncio
 async def test_crawl_retries_cleanup_induced_near_empty_result(
-    tmp_path,
-    monkeypatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler("example", site_config())
@@ -228,7 +228,7 @@ async def test_crawl_retries_cleanup_induced_near_empty_result(
 
 
 @pytest.mark.asyncio
-async def test_crawl_handles_browser_launch_failure(tmp_path, monkeypatch) -> None:
+async def test_crawl_handles_browser_launch_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
     crawler = Crawl4AICrawler("example", site_config())
     browser = MagicMock()

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -1,5 +1,7 @@
 """Tests for the discovery runner."""
 
+from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -26,7 +28,7 @@ def _site_config(**crawler_overrides: object) -> SiteConfig:
 
 
 @pytest.fixture
-def store(tmp_path) -> ManifestStore:
+def store(tmp_path: Path) -> Generator[ManifestStore]:
     manifest_store = ManifestStore(path=str(tmp_path / "manifest.db"))
     yield manifest_store
     manifest_store.close()

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -21,6 +21,14 @@ from tapio_crawler.manifest.store import ManifestStore
 
 
 def _site_config(**crawler_overrides: object) -> SiteConfig:
+    """Build a minimal ``SiteConfig``, overriding fields on its crawler config.
+
+    Args:
+        **crawler_overrides: Field values to override on the ``CrawlerConfig``.
+
+    Returns:
+        The constructed site configuration.
+    """
     return SiteConfig(
         base_url="https://example.com",
         crawler_config=CrawlerConfig(**crawler_overrides),
@@ -29,6 +37,7 @@ def _site_config(**crawler_overrides: object) -> SiteConfig:
 
 @pytest.fixture
 def store(tmp_path: Path) -> Generator[ManifestStore]:
+    """Yield a ``ManifestStore`` backed by a temporary database file."""
     manifest_store = ManifestStore(path=str(tmp_path / "manifest.db"))
     yield manifest_store
     manifest_store.close()
@@ -36,6 +45,7 @@ def store(tmp_path: Path) -> Generator[ManifestStore]:
 
 @pytest.mark.asyncio
 async def test_raises_when_no_sitemap_and_no_gap_crawl(store: ManifestStore) -> None:
+    """A site with no sitemap and no gap-crawl configured raises."""
     runner = DiscoveryRunner(store)
     site_config = _site_config(discovery=DiscoveryConfig(source="none"))
 
@@ -47,11 +57,10 @@ async def test_raises_when_no_sitemap_and_no_gap_crawl(store: ManifestStore) -> 
 async def test_marks_run_incomplete_when_robots_unreachable(
     store: ManifestStore,
 ) -> None:
+    """An unreachable robots.txt marks the run incomplete with no discoveries."""
     runner = DiscoveryRunner(store)
     site_config = _site_config(
-        discovery=DiscoveryConfig(
-            source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]
-        ),
+        discovery=DiscoveryConfig(source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]),
     )
 
     with patch(
@@ -68,14 +77,13 @@ async def test_marks_run_incomplete_when_robots_unreachable(
 async def test_sitemap_discovery_upserts_eligible_and_excluded_urls(
     store: ManifestStore,
 ) -> None:
+    """Sitemap discovery upserts both eligible and excluded URLs, tagged with
+    their scope status.
+    """
     runner = DiscoveryRunner(store)
     site_config = _site_config(
-        discovery=DiscoveryConfig(
-            source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]
-        ),
-        scope=ScopeConfig(
-            allowed_domains=["example.com"], exclude_url_patterns=["*/search*"]
-        ),
+        discovery=DiscoveryConfig(source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]),
+        scope=ScopeConfig(allowed_domains=["example.com"], exclude_url_patterns=["*/search*"]),
     )
 
     fake_sitemap_result = SitemapDiscoveryResult(
@@ -113,6 +121,7 @@ async def test_sitemap_discovery_upserts_eligible_and_excluded_urls(
 
 @pytest.mark.asyncio
 async def test_gap_crawl_discovery_used_when_no_sitemap(store: ManifestStore) -> None:
+    """Gap-crawl discovery is used when no sitemap source is configured."""
     runner = DiscoveryRunner(store)
     site_config = _site_config(
         discovery=DiscoveryConfig(source="none"),
@@ -128,9 +137,7 @@ async def test_gap_crawl_discovery_used_when_no_sitemap(store: ManifestStore) ->
         patch(
             "tapio_crawler.discovery.runner.discover_via_gap_crawl",
             AsyncMock(
-                return_value=GapCrawlResult(
-                    urls=["https://example.com/b"], complete=True
-                ),
+                return_value=GapCrawlResult(urls=["https://example.com/b"], complete=True),
             ),
         ),
     ):

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -1,0 +1,138 @@
+"""Tests for the discovery runner."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tapio_crawler.config.config_models import (
+    CrawlerConfig,
+    DiscoveryConfig,
+    GapCrawlConfig,
+    ScopeConfig,
+    SiteConfig,
+)
+from tapio_crawler.discovery.gap_crawl import GapCrawlResult
+from tapio_crawler.discovery.robots import RobotsRules
+from tapio_crawler.discovery.runner import DiscoveryRunner, MisconfiguredDiscoveryError
+from tapio_crawler.discovery.sitemap import SitemapDiscoveryResult, SitemapUrlEntry
+from tapio_crawler.manifest.store import ManifestStore
+
+
+def _site_config(**crawler_overrides: object) -> SiteConfig:
+    return SiteConfig(
+        base_url="https://example.com",
+        crawler_config=CrawlerConfig(**crawler_overrides),
+    )
+
+
+@pytest.fixture
+def store(tmp_path) -> ManifestStore:
+    manifest_store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    yield manifest_store
+    manifest_store.close()
+
+
+@pytest.mark.asyncio
+async def test_raises_when_no_sitemap_and_no_gap_crawl(store: ManifestStore) -> None:
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(discovery=DiscoveryConfig(source="none"))
+
+    with pytest.raises(MisconfiguredDiscoveryError):
+        await runner.run("example", site_config)
+
+
+@pytest.mark.asyncio
+async def test_marks_run_incomplete_when_robots_unreachable(
+    store: ManifestStore,
+) -> None:
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]
+        ),
+    )
+
+    with patch(
+        "tapio_crawler.discovery.runner.fetch_robots_rules",
+        AsyncMock(return_value=RobotsRules(reachable=False)),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.complete is False
+    assert summary.discovered == 0
+
+
+@pytest.mark.asyncio
+async def test_sitemap_discovery_upserts_eligible_and_excluded_urls(
+    store: ManifestStore,
+) -> None:
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]
+        ),
+        scope=ScopeConfig(
+            allowed_domains=["example.com"], exclude_url_patterns=["*/search*"]
+        ),
+    )
+
+    fake_sitemap_result = SitemapDiscoveryResult(
+        urls=[
+            SitemapUrlEntry(url="https://example.com/a"),
+            SitemapUrlEntry(url="https://example.com/search"),
+        ],
+        child_sitemaps_fetched=1,
+        complete=True,
+    )
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ),
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.discovered == 2
+    assert summary.eligible == 1
+    assert summary.excluded_by_reason == {"excluded_by_pattern": 1}
+
+    records = store.list_by_site("example")
+    assert len(records) == 2
+    eligible = next(r for r in records if r.canonical_url.endswith("/a"))
+    assert eligible.scope_status == "eligible"
+    excluded = next(r for r in records if r.canonical_url.endswith("/search"))
+    assert excluded.scope_status == "excluded"
+
+
+@pytest.mark.asyncio
+async def test_gap_crawl_discovery_used_when_no_sitemap(store: ManifestStore) -> None:
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(source="none"),
+        gap_crawl=GapCrawlConfig(enabled=True, seed_urls=["https://example.com"]),
+        scope=ScopeConfig(allowed_domains=["example.com"]),
+    )
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ),
+        patch(
+            "tapio_crawler.discovery.runner.discover_via_gap_crawl",
+            AsyncMock(
+                return_value=GapCrawlResult(
+                    urls=["https://example.com/b"], complete=True
+                ),
+            ),
+        ),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.discovered == 1
+    assert summary.eligible == 1

--- a/crawler/tests/discovery/test_gap_crawl.py
+++ b/crawler/tests/discovery/test_gap_crawl.py
@@ -6,6 +6,7 @@ import pytest
 
 from tapio_crawler.config.config_models import GapCrawlConfig, ScopeConfig
 from tapio_crawler.discovery.gap_crawl import discover_via_gap_crawl
+from tapio_crawler.discovery.rate_limiter import HostRateLimiter
 
 
 class _FakeResult:
@@ -20,8 +21,7 @@ async def test_returns_incomplete_when_gap_crawl_disabled() -> None:
         GapCrawlConfig(enabled=False),
         ScopeConfig(),
         user_agent="TapioBot/1.0",
-        min_delay=1.0,
-        max_delay=2.0,
+        rate_limiter=HostRateLimiter(min_delay=1.0, max_delay=2.0),
         max_concurrent=2,
     )
 
@@ -35,8 +35,7 @@ async def test_returns_incomplete_when_no_seed_urls() -> None:
         GapCrawlConfig(enabled=True, seed_urls=[]),
         ScopeConfig(),
         user_agent="TapioBot/1.0",
-        min_delay=1.0,
-        max_delay=2.0,
+        rate_limiter=HostRateLimiter(min_delay=1.0, max_delay=2.0),
         max_concurrent=2,
     )
 
@@ -51,7 +50,7 @@ async def test_collects_successful_urls_from_crawl() -> None:
     ]
 
     mock_crawler = AsyncMock()
-    mock_crawler.arun = AsyncMock(return_value=fake_results)
+    mock_crawler.arun_many = AsyncMock(return_value=fake_results)
     mock_crawler.__aenter__.return_value = mock_crawler
     mock_crawler.__aexit__.return_value = False
 
@@ -60,22 +59,27 @@ async def test_collects_successful_urls_from_crawl() -> None:
         return_value=mock_crawler,
     ):
         result = await discover_via_gap_crawl(
-            GapCrawlConfig(enabled=True, seed_urls=["https://example.com"]),
+            GapCrawlConfig(
+                enabled=True,
+                seed_urls=["https://example.com", "https://example.com/other"],
+            ),
             ScopeConfig(allowed_domains=["example.com"]),
             user_agent="TapioBot/1.0",
-            min_delay=1.0,
-            max_delay=2.0,
+            rate_limiter=HostRateLimiter(min_delay=1.0, max_delay=2.0),
             max_concurrent=2,
         )
 
     assert result.complete is True
     assert result.urls == ["https://example.com/a"]
+    mock_crawler.arun_many.assert_awaited_once()
+    called_urls = mock_crawler.arun_many.call_args.args[0]
+    assert called_urls == ["https://example.com", "https://example.com/other"]
 
 
 @pytest.mark.asyncio
 async def test_marks_incomplete_on_crawl_exception() -> None:
     mock_crawler = AsyncMock()
-    mock_crawler.arun = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_crawler.arun_many = AsyncMock(side_effect=RuntimeError("boom"))
     mock_crawler.__aenter__.return_value = mock_crawler
     mock_crawler.__aexit__.return_value = False
 
@@ -87,8 +91,7 @@ async def test_marks_incomplete_on_crawl_exception() -> None:
             GapCrawlConfig(enabled=True, seed_urls=["https://example.com"]),
             ScopeConfig(),
             user_agent="TapioBot/1.0",
-            min_delay=1.0,
-            max_delay=2.0,
+            rate_limiter=HostRateLimiter(min_delay=1.0, max_delay=2.0),
             max_concurrent=2,
         )
 

--- a/crawler/tests/discovery/test_gap_crawl.py
+++ b/crawler/tests/discovery/test_gap_crawl.py
@@ -49,10 +49,7 @@ async def test_returns_incomplete_when_no_seed_urls() -> None:
 @pytest.mark.asyncio
 async def test_collects_successful_urls_from_crawl() -> None:
     """Only URLs from successful crawl results are collected."""
-    fake_results = [
-        _FakeResult("https://example.com/a"),
-        _FakeResult("https://example.com/b", success=False),
-    ]
+    fake_results = [_FakeResult("https://example.com/a")]
 
     mock_crawler = AsyncMock()
     mock_crawler.arun_many = AsyncMock(return_value=fake_results)
@@ -79,6 +76,38 @@ async def test_collects_successful_urls_from_crawl() -> None:
     mock_crawler.arun_many.assert_awaited_once()
     called_urls = mock_crawler.arun_many.call_args.args[0]
     assert called_urls == ["https://example.com", "https://example.com/other"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_results_omit_failed_urls_and_mark_incomplete() -> None:
+    """A mix of successful and failed results drops the failures but is incomplete."""
+    fake_results = [
+        _FakeResult("https://example.com/a"),
+        _FakeResult("https://example.com/b", success=False),
+    ]
+
+    mock_crawler = AsyncMock()
+    mock_crawler.arun_many = AsyncMock(return_value=fake_results)
+    mock_crawler.__aenter__.return_value = mock_crawler
+    mock_crawler.__aexit__.return_value = False
+
+    with patch(
+        "tapio_crawler.discovery.gap_crawl.AsyncWebCrawler",
+        return_value=mock_crawler,
+    ):
+        result = await discover_via_gap_crawl(
+            GapCrawlConfig(
+                enabled=True,
+                seed_urls=["https://example.com", "https://example.com/other"],
+            ),
+            ScopeConfig(allowed_domains=["example.com"]),
+            user_agent="TapioBot/1.0",
+            rate_limiter=HostRateLimiter(min_delay=1.0, max_delay=2.0),
+            max_concurrent=2,
+        )
+
+    assert result.complete is False
+    assert result.urls == ["https://example.com/a"]
 
 
 @pytest.mark.asyncio

--- a/crawler/tests/discovery/test_gap_crawl.py
+++ b/crawler/tests/discovery/test_gap_crawl.py
@@ -10,13 +10,16 @@ from tapio_crawler.discovery.rate_limiter import HostRateLimiter
 
 
 class _FakeResult:
-    def __init__(self, url: str, success: bool = True) -> None:
+    """Stand-in for a crawl4ai crawl result exposing ``url`` and ``success``."""
+
+    def __init__(self, url: str, *, success: bool = True) -> None:
         self.url = url
         self.success = success
 
 
 @pytest.mark.asyncio
 async def test_returns_incomplete_when_gap_crawl_disabled() -> None:
+    """A disabled gap-crawl config yields no URLs and an incomplete result."""
     result = await discover_via_gap_crawl(
         GapCrawlConfig(enabled=False),
         ScopeConfig(),
@@ -31,6 +34,7 @@ async def test_returns_incomplete_when_gap_crawl_disabled() -> None:
 
 @pytest.mark.asyncio
 async def test_returns_incomplete_when_no_seed_urls() -> None:
+    """Gap-crawl with no seed URLs configured yields an incomplete result."""
     result = await discover_via_gap_crawl(
         GapCrawlConfig(enabled=True, seed_urls=[]),
         ScopeConfig(),
@@ -44,6 +48,7 @@ async def test_returns_incomplete_when_no_seed_urls() -> None:
 
 @pytest.mark.asyncio
 async def test_collects_successful_urls_from_crawl() -> None:
+    """Only URLs from successful crawl results are collected."""
     fake_results = [
         _FakeResult("https://example.com/a"),
         _FakeResult("https://example.com/b", success=False),
@@ -78,6 +83,7 @@ async def test_collects_successful_urls_from_crawl() -> None:
 
 @pytest.mark.asyncio
 async def test_marks_incomplete_on_crawl_exception() -> None:
+    """An exception raised by the crawler marks the result incomplete."""
     mock_crawler = AsyncMock()
     mock_crawler.arun_many = AsyncMock(side_effect=RuntimeError("boom"))
     mock_crawler.__aenter__.return_value = mock_crawler

--- a/crawler/tests/discovery/test_gap_crawl.py
+++ b/crawler/tests/discovery/test_gap_crawl.py
@@ -1,0 +1,95 @@
+"""Tests for bounded gap-crawl discovery."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tapio_crawler.config.config_models import GapCrawlConfig, ScopeConfig
+from tapio_crawler.discovery.gap_crawl import discover_via_gap_crawl
+
+
+class _FakeResult:
+    def __init__(self, url: str, success: bool = True) -> None:
+        self.url = url
+        self.success = success
+
+
+@pytest.mark.asyncio
+async def test_returns_incomplete_when_gap_crawl_disabled() -> None:
+    result = await discover_via_gap_crawl(
+        GapCrawlConfig(enabled=False),
+        ScopeConfig(),
+        user_agent="TapioBot/1.0",
+        min_delay=1.0,
+        max_delay=2.0,
+        max_concurrent=2,
+    )
+
+    assert result.complete is False
+    assert result.urls == []
+
+
+@pytest.mark.asyncio
+async def test_returns_incomplete_when_no_seed_urls() -> None:
+    result = await discover_via_gap_crawl(
+        GapCrawlConfig(enabled=True, seed_urls=[]),
+        ScopeConfig(),
+        user_agent="TapioBot/1.0",
+        min_delay=1.0,
+        max_delay=2.0,
+        max_concurrent=2,
+    )
+
+    assert result.complete is False
+
+
+@pytest.mark.asyncio
+async def test_collects_successful_urls_from_crawl() -> None:
+    fake_results = [
+        _FakeResult("https://example.com/a"),
+        _FakeResult("https://example.com/b", success=False),
+    ]
+
+    mock_crawler = AsyncMock()
+    mock_crawler.arun = AsyncMock(return_value=fake_results)
+    mock_crawler.__aenter__.return_value = mock_crawler
+    mock_crawler.__aexit__.return_value = False
+
+    with patch(
+        "tapio_crawler.discovery.gap_crawl.AsyncWebCrawler",
+        return_value=mock_crawler,
+    ):
+        result = await discover_via_gap_crawl(
+            GapCrawlConfig(enabled=True, seed_urls=["https://example.com"]),
+            ScopeConfig(allowed_domains=["example.com"]),
+            user_agent="TapioBot/1.0",
+            min_delay=1.0,
+            max_delay=2.0,
+            max_concurrent=2,
+        )
+
+    assert result.complete is True
+    assert result.urls == ["https://example.com/a"]
+
+
+@pytest.mark.asyncio
+async def test_marks_incomplete_on_crawl_exception() -> None:
+    mock_crawler = AsyncMock()
+    mock_crawler.arun = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_crawler.__aenter__.return_value = mock_crawler
+    mock_crawler.__aexit__.return_value = False
+
+    with patch(
+        "tapio_crawler.discovery.gap_crawl.AsyncWebCrawler",
+        return_value=mock_crawler,
+    ):
+        result = await discover_via_gap_crawl(
+            GapCrawlConfig(enabled=True, seed_urls=["https://example.com"]),
+            ScopeConfig(),
+            user_agent="TapioBot/1.0",
+            min_delay=1.0,
+            max_delay=2.0,
+            max_concurrent=2,
+        )
+
+    assert result.complete is False

--- a/crawler/tests/discovery/test_rate_limiter.py
+++ b/crawler/tests/discovery/test_rate_limiter.py
@@ -54,7 +54,9 @@ def test_resolve_effective_delay_never_produces_negative_range() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wait_for_turn_serializes_requests(monkeypatch) -> None:
+async def test_wait_for_turn_serializes_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     limiter = HostRateLimiter(min_delay=0.01, max_delay=0.01)
     sleeps: list[float] = []
 

--- a/crawler/tests/discovery/test_rate_limiter.py
+++ b/crawler/tests/discovery/test_rate_limiter.py
@@ -1,0 +1,114 @@
+"""Tests for the shared per-host rate limiter."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
+
+import pytest
+
+from tapio_crawler.discovery.rate_limiter import (
+    HostRateLimiter,
+    resolve_effective_delay,
+)
+
+
+def test_resolve_effective_delay_without_crawl_delay_keeps_config() -> None:
+    delay = resolve_effective_delay(
+        configured_min_delay=1.0,
+        configured_max_delay=3.0,
+        crawl_delay=None,
+    )
+
+    assert (delay.min_delay, delay.max_delay) == (1.0, 3.0)
+
+
+def test_resolve_effective_delay_raises_floor_to_crawl_delay() -> None:
+    delay = resolve_effective_delay(
+        configured_min_delay=1.0,
+        configured_max_delay=3.0,
+        crawl_delay=5.0,
+    )
+
+    assert delay.min_delay == 5.0
+    assert delay.max_delay == 5.0
+
+
+def test_resolve_effective_delay_keeps_wider_configured_max() -> None:
+    delay = resolve_effective_delay(
+        configured_min_delay=1.0,
+        configured_max_delay=8.0,
+        crawl_delay=5.0,
+    )
+
+    assert (delay.min_delay, delay.max_delay) == (5.0, 8.0)
+
+
+def test_resolve_effective_delay_never_produces_negative_range() -> None:
+    delay = resolve_effective_delay(
+        configured_min_delay=0.0,
+        configured_max_delay=0.0,
+        crawl_delay=5.0,
+    )
+
+    assert delay.max_delay >= delay.min_delay
+
+
+@pytest.mark.asyncio
+async def test_wait_for_turn_serializes_requests(monkeypatch) -> None:
+    limiter = HostRateLimiter(min_delay=0.01, max_delay=0.01)
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await limiter.wait_for_turn()
+    await limiter.wait_for_turn()
+
+    assert len(sleeps) == 1
+    assert sleeps[0] > 0
+
+
+def test_suspend_for_retry_after_parses_delay_seconds() -> None:
+    limiter = HostRateLimiter(min_delay=1.0, max_delay=3.0)
+
+    applied = limiter.suspend_for_retry_after("30")
+
+    assert applied == 30.0
+    assert limiter.last_suspension_capped is False
+
+
+def test_suspend_for_retry_after_parses_http_date() -> None:
+    limiter = HostRateLimiter(min_delay=1.0, max_delay=3.0)
+    future = datetime.now(UTC) + timedelta(seconds=60)
+
+    applied = limiter.suspend_for_retry_after(format_datetime(future, usegmt=True))
+
+    assert applied == pytest.approx(60.0, abs=2.0)
+
+
+def test_suspend_for_retry_after_falls_back_on_missing_value() -> None:
+    limiter = HostRateLimiter(min_delay=1.0, max_delay=3.0)
+
+    applied = limiter.suspend_for_retry_after(None)
+
+    assert applied == 3.0
+    assert limiter.last_suspension_capped is False
+
+
+def test_suspend_for_retry_after_falls_back_on_unparseable_value() -> None:
+    limiter = HostRateLimiter(min_delay=1.0, max_delay=3.0)
+
+    applied = limiter.suspend_for_retry_after("not-a-value")
+
+    assert applied == 3.0
+
+
+def test_suspend_for_retry_after_caps_at_configured_maximum() -> None:
+    limiter = HostRateLimiter(min_delay=1.0, max_delay=3.0, max_suspension_seconds=60)
+
+    applied = limiter.suspend_for_retry_after("3600")
+
+    assert applied == 60
+    assert limiter.last_suspension_capped is True

--- a/crawler/tests/discovery/test_robots.py
+++ b/crawler/tests/discovery/test_robots.py
@@ -45,7 +45,8 @@ async def test_server_error_is_reported_unreachable() -> None:
 @pytest.mark.asyncio
 async def test_connection_error_is_reported_unreachable() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=request)
+        msg = "boom"
+        raise httpx.ConnectError(msg, request=request)
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:

--- a/crawler/tests/discovery/test_robots.py
+++ b/crawler/tests/discovery/test_robots.py
@@ -1,0 +1,134 @@
+"""Tests for robots.txt fetching and fail-closed parsing."""
+
+import httpx
+import pytest
+
+from tapio_crawler.discovery.robots import fetch_robots_rules
+
+USER_AGENT = "TapioBot/1.0 (+https://github.com/Finntegrate/tapio)"
+
+
+@pytest.mark.asyncio
+async def test_missing_robots_txt_is_reachable_with_no_restrictions() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.reachable is True
+    assert rules.crawl_delay is None
+    assert rules.can_fetch(USER_AGENT, "https://example.com/anything") is True
+
+
+@pytest.mark.asyncio
+async def test_server_error_is_reported_unreachable() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.reachable is False
+
+
+@pytest.mark.asyncio
+async def test_connection_error_is_reported_unreachable() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.reachable is False
+
+
+@pytest.mark.asyncio
+async def test_own_user_agent_crawl_delay_takes_precedence_over_wildcard() -> None:
+    # robots.txt conventionally names a bot by its short product token, not
+    # the full descriptive User-Agent header string sent in requests.
+    body = "User-agent: TapioBot\nCrawl-delay: 5\n\nUser-agent: *\nCrawl-delay: 1\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.reachable is True
+    assert rules.crawl_delay == 5.0
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_wildcard_crawl_delay() -> None:
+    body = "User-agent: *\nCrawl-delay: 2\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.crawl_delay == 2.0
+
+
+@pytest.mark.asyncio
+async def test_disallowed_path_is_reported() -> None:
+    body = "User-agent: TapioBot\nDisallow: /private/\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.can_fetch(USER_AGENT, "https://example.com/private/page") is False
+    assert rules.can_fetch(USER_AGENT, "https://example.com/public/page") is True
+
+
+@pytest.mark.asyncio
+async def test_extracts_sitemap_urls() -> None:
+    body = "Sitemap: https://example.com/sitemap.xml\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.sitemap_urls == ["https://example.com/sitemap.xml"]

--- a/crawler/tests/discovery/test_robots.py
+++ b/crawler/tests/discovery/test_robots.py
@@ -98,6 +98,24 @@ async def test_falls_back_to_wildcard_crawl_delay() -> None:
 
 
 @pytest.mark.asyncio
+async def test_non_numeric_crawl_delay_is_ignored() -> None:
+    body = "User-agent: *\nCrawl-delay: soon\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.crawl_delay is None
+
+
+@pytest.mark.asyncio
 async def test_disallowed_path_is_reported() -> None:
     body = "User-agent: TapioBot\nDisallow: /private/\n"
 

--- a/crawler/tests/discovery/test_scope.py
+++ b/crawler/tests/discovery/test_scope.py
@@ -5,6 +5,7 @@ from tapio_crawler.discovery.scope import evaluate_scope
 
 
 def test_rejects_url_outside_allowed_domains() -> None:
+    """A URL whose host is not in ``allowed_domains`` is rejected."""
     scope = ScopeConfig(allowed_domains=["migri.fi"])
 
     decision = evaluate_scope("https://evil.example/en/page", scope)
@@ -14,6 +15,7 @@ def test_rejects_url_outside_allowed_domains() -> None:
 
 
 def test_accepts_url_within_allowed_domains() -> None:
+    """A URL whose host is in ``allowed_domains`` is accepted."""
     scope = ScopeConfig(allowed_domains=["migri.fi"])
 
     decision = evaluate_scope("https://migri.fi/en/page", scope)
@@ -22,6 +24,7 @@ def test_accepts_url_within_allowed_domains() -> None:
 
 
 def test_rejects_url_matching_exclude_pattern() -> None:
+    """A URL matching an exclude pattern is rejected."""
     scope = ScopeConfig(exclude_url_patterns=["*/search*"])
 
     decision = evaluate_scope("https://migri.fi/en/search", scope)
@@ -31,6 +34,7 @@ def test_rejects_url_matching_exclude_pattern() -> None:
 
 
 def test_rejects_url_with_tracking_query_pattern() -> None:
+    """A URL matching an exclude pattern on its query string is rejected."""
     scope = ScopeConfig(exclude_url_patterns=["*?*utm_*"])
 
     decision = evaluate_scope("https://migri.fi/en/page?utm_source=x", scope)
@@ -39,6 +43,7 @@ def test_rejects_url_with_tracking_query_pattern() -> None:
 
 
 def test_rejects_url_outside_include_patterns() -> None:
+    """A URL not matching any include pattern is rejected."""
     scope = ScopeConfig(include_url_patterns=["/en/*"])
 
     decision = evaluate_scope("https://migri.fi/fi/sivu", scope)
@@ -48,6 +53,7 @@ def test_rejects_url_outside_include_patterns() -> None:
 
 
 def test_accepts_url_within_include_patterns() -> None:
+    """A URL matching an include pattern is accepted."""
     scope = ScopeConfig(include_url_patterns=["/en/*"])
 
     decision = evaluate_scope("https://migri.fi/en/page", scope)
@@ -56,6 +62,7 @@ def test_accepts_url_within_include_patterns() -> None:
 
 
 def test_no_configured_rules_accepts_everything() -> None:
+    """With no scope rules configured, every URL is accepted."""
     decision = evaluate_scope("https://anything.example/path", ScopeConfig())
 
     assert decision.eligible is True

--- a/crawler/tests/discovery/test_scope.py
+++ b/crawler/tests/discovery/test_scope.py
@@ -1,0 +1,61 @@
+"""Tests for domain/path scope evaluation."""
+
+from tapio_crawler.config.config_models import ScopeConfig
+from tapio_crawler.discovery.scope import evaluate_scope
+
+
+def test_rejects_url_outside_allowed_domains() -> None:
+    scope = ScopeConfig(allowed_domains=["migri.fi"])
+
+    decision = evaluate_scope("https://evil.example/en/page", scope)
+
+    assert decision.eligible is False
+    assert decision.reason == "domain_not_allowed"
+
+
+def test_accepts_url_within_allowed_domains() -> None:
+    scope = ScopeConfig(allowed_domains=["migri.fi"])
+
+    decision = evaluate_scope("https://migri.fi/en/page", scope)
+
+    assert decision.eligible is True
+
+
+def test_rejects_url_matching_exclude_pattern() -> None:
+    scope = ScopeConfig(exclude_url_patterns=["*/search*"])
+
+    decision = evaluate_scope("https://migri.fi/en/search", scope)
+
+    assert decision.eligible is False
+    assert decision.reason == "excluded_by_pattern"
+
+
+def test_rejects_url_with_tracking_query_pattern() -> None:
+    scope = ScopeConfig(exclude_url_patterns=["*?*utm_*"])
+
+    decision = evaluate_scope("https://migri.fi/en/page?utm_source=x", scope)
+
+    assert decision.eligible is False
+
+
+def test_rejects_url_outside_include_patterns() -> None:
+    scope = ScopeConfig(include_url_patterns=["/en/*"])
+
+    decision = evaluate_scope("https://migri.fi/fi/sivu", scope)
+
+    assert decision.eligible is False
+    assert decision.reason == "not_in_include_patterns"
+
+
+def test_accepts_url_within_include_patterns() -> None:
+    scope = ScopeConfig(include_url_patterns=["/en/*"])
+
+    decision = evaluate_scope("https://migri.fi/en/page", scope)
+
+    assert decision.eligible is True
+
+
+def test_no_configured_rules_accepts_everything() -> None:
+    decision = evaluate_scope("https://anything.example/path", ScopeConfig())
+
+    assert decision.eligible is True

--- a/crawler/tests/discovery/test_sitemap.py
+++ b/crawler/tests/discovery/test_sitemap.py
@@ -26,11 +26,14 @@ SITEMAP_INDEX = """<?xml version="1.0" encoding="UTF-8"?>
 
 
 def _limiter() -> HostRateLimiter:
+    """Return a rate limiter with no delay, for fast tests."""
     return HostRateLimiter(min_delay=0.0, max_delay=0.0)
 
 
 @pytest.mark.asyncio
 async def test_discovers_urls_and_lastmod_from_flat_urlset() -> None:
+    """A flat urlset yields each URL with its ``lastmod``, or ``None`` if absent."""
+
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, text=FLAT_URLSET)
 
@@ -52,6 +55,8 @@ async def test_discovers_urls_and_lastmod_from_flat_urlset() -> None:
 
 @pytest.mark.asyncio
 async def test_follows_sitemap_index_and_counts_child_sitemaps_separately() -> None:
+    """A sitemap index is followed and only its children count as fetched."""
+
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/sitemap.xml":
             return httpx.Response(200, text=SITEMAP_INDEX)
@@ -74,6 +79,8 @@ async def test_follows_sitemap_index_and_counts_child_sitemaps_separately() -> N
 
 @pytest.mark.asyncio
 async def test_marks_incomplete_when_a_sitemap_fetch_fails() -> None:
+    """An HTTP error fetching the sitemap marks the result incomplete."""
+
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)
 
@@ -92,6 +99,8 @@ async def test_marks_incomplete_when_a_sitemap_fetch_fails() -> None:
 
 @pytest.mark.asyncio
 async def test_marks_incomplete_when_sitemap_is_unparseable() -> None:
+    """Non-XML sitemap content marks the result incomplete."""
+
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, text="not xml")
 
@@ -109,6 +118,7 @@ async def test_marks_incomplete_when_sitemap_is_unparseable() -> None:
 
 @pytest.mark.asyncio
 async def test_no_sitemap_urls_is_incomplete() -> None:
+    """An empty list of sitemap URLs yields an incomplete result."""
     async with httpx.AsyncClient() as client:
         result = await discover_sitemap_urls(
             [],
@@ -122,6 +132,10 @@ async def test_no_sitemap_urls_is_incomplete() -> None:
 
 @pytest.mark.asyncio
 async def test_429_suspends_host_and_marks_incomplete() -> None:
+    """A 429 response suspends the host's rate limiter and marks the result
+    incomplete.
+    """
+
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(429, headers={"Retry-After": "1"})
 

--- a/crawler/tests/discovery/test_sitemap.py
+++ b/crawler/tests/discovery/test_sitemap.py
@@ -1,0 +1,136 @@
+"""Tests for sitemap fetching and parsing."""
+
+import httpx
+import pytest
+
+from tapio_crawler.discovery.rate_limiter import HostRateLimiter
+from tapio_crawler.discovery.sitemap import discover_sitemap_urls
+
+USER_AGENT = "TapioBot/1.0"
+
+FLAT_URLSET = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/a</loc><lastmod>2026-01-01</lastmod></url>
+  <url><loc>https://example.com/b</loc></url>
+</urlset>
+"""
+
+SITEMAP_INDEX = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap-1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap-2.xml</loc></sitemap>
+</sitemapindex>
+"""
+
+
+def _limiter() -> HostRateLimiter:
+    return HostRateLimiter(min_delay=0.0, max_delay=0.0)
+
+
+@pytest.mark.asyncio
+async def test_discovers_urls_and_lastmod_from_flat_urlset() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=FLAT_URLSET)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await discover_sitemap_urls(
+            ["https://example.com/sitemap.xml"],
+            client=client,
+            rate_limiter=_limiter(),
+            user_agent=USER_AGENT,
+        )
+
+    assert result.complete is True
+    assert result.child_sitemaps_fetched == 1
+    urls = {entry.url: entry.lastmod for entry in result.urls}
+    assert urls["https://example.com/a"] is not None
+    assert urls["https://example.com/b"] is None
+
+
+@pytest.mark.asyncio
+async def test_follows_sitemap_index_and_counts_child_sitemaps_separately() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/sitemap.xml":
+            return httpx.Response(200, text=SITEMAP_INDEX)
+        return httpx.Response(200, text=FLAT_URLSET)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await discover_sitemap_urls(
+            ["https://example.com/sitemap.xml"],
+            client=client,
+            rate_limiter=_limiter(),
+            user_agent=USER_AGENT,
+        )
+
+    # 1 index + 2 child sitemaps fetched; each child contributes 2 URLs.
+    assert result.child_sitemaps_fetched == 3
+    assert len(result.urls) == 4
+    assert result.complete is True
+
+
+@pytest.mark.asyncio
+async def test_marks_incomplete_when_a_sitemap_fetch_fails() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await discover_sitemap_urls(
+            ["https://example.com/sitemap.xml"],
+            client=client,
+            rate_limiter=_limiter(),
+            user_agent=USER_AGENT,
+        )
+
+    assert result.complete is False
+    assert result.urls == []
+
+
+@pytest.mark.asyncio
+async def test_marks_incomplete_when_sitemap_is_unparseable() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not xml")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await discover_sitemap_urls(
+            ["https://example.com/sitemap.xml"],
+            client=client,
+            rate_limiter=_limiter(),
+            user_agent=USER_AGENT,
+        )
+
+    assert result.complete is False
+
+
+@pytest.mark.asyncio
+async def test_no_sitemap_urls_is_incomplete() -> None:
+    async with httpx.AsyncClient() as client:
+        result = await discover_sitemap_urls(
+            [],
+            client=client,
+            rate_limiter=_limiter(),
+            user_agent=USER_AGENT,
+        )
+
+    assert result.complete is False
+
+
+@pytest.mark.asyncio
+async def test_429_suspends_host_and_marks_incomplete() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "1"})
+
+    transport = httpx.MockTransport(handler)
+    limiter = _limiter()
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await discover_sitemap_urls(
+            ["https://example.com/sitemap.xml"],
+            client=client,
+            rate_limiter=limiter,
+            user_agent=USER_AGENT,
+        )
+
+    assert result.complete is False

--- a/crawler/tests/discovery/test_sitemap.py
+++ b/crawler/tests/discovery/test_sitemap.py
@@ -24,6 +24,12 @@ SITEMAP_INDEX = """<?xml version="1.0" encoding="UTF-8"?>
 </sitemapindex>
 """
 
+SITEMAP_INDEX_WITH_SSRF_CHILD = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://127.0.0.1/internal-sitemap.xml</loc></sitemap>
+</sitemapindex>
+"""
+
 
 def _limiter() -> HostRateLimiter:
     """Return a rate limiter with no delay, for fast tests."""
@@ -127,6 +133,33 @@ async def test_no_sitemap_urls_is_incomplete() -> None:
             user_agent=USER_AGENT,
         )
 
+    assert result.complete is False
+
+
+@pytest.mark.asyncio
+async def test_child_sitemap_outside_source_host_is_never_fetched() -> None:
+    """A child <loc> pointing off the source host is rejected, even with no
+    ``allowed_hosts`` configured, and its host is never requested.
+    """
+    requested_hosts: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested_hosts.append(request.url.host)
+        if request.url.host == "127.0.0.1":
+            return httpx.Response(200, text=FLAT_URLSET)
+        return httpx.Response(200, text=SITEMAP_INDEX_WITH_SSRF_CHILD)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await discover_sitemap_urls(
+            ["https://example.com/sitemap.xml"],
+            client=client,
+            rate_limiter=_limiter(),
+            user_agent=USER_AGENT,
+        )
+
+    assert "127.0.0.1" not in requested_hosts
+    assert result.urls == []
     assert result.complete is False
 
 

--- a/crawler/tests/discovery/test_sitemap.py
+++ b/crawler/tests/discovery/test_sitemap.py
@@ -1,5 +1,7 @@
 """Tests for sitemap fetching and parsing."""
 
+import time
+
 import httpx
 import pytest
 
@@ -42,7 +44,7 @@ async def test_discovers_urls_and_lastmod_from_flat_urlset() -> None:
         )
 
     assert result.complete is True
-    assert result.child_sitemaps_fetched == 1
+    assert result.child_sitemaps_fetched == 0
     urls = {entry.url: entry.lastmod for entry in result.urls}
     assert urls["https://example.com/a"] is not None
     assert urls["https://example.com/b"] is None
@@ -64,8 +66,8 @@ async def test_follows_sitemap_index_and_counts_child_sitemaps_separately() -> N
             user_agent=USER_AGENT,
         )
 
-    # 1 index + 2 child sitemaps fetched; each child contributes 2 URLs.
-    assert result.child_sitemaps_fetched == 3
+    # The index itself is a top-level entry, not a child; only its 2 children count.
+    assert result.child_sitemaps_fetched == 2
     assert len(result.urls) == 4
     assert result.complete is True
 
@@ -134,3 +136,5 @@ async def test_429_suspends_host_and_marks_incomplete() -> None:
         )
 
     assert result.complete is False
+    assert limiter.last_suspension_capped is False
+    assert limiter._next_available_at > time.monotonic()

--- a/crawler/tests/manifest/test_normalize.py
+++ b/crawler/tests/manifest/test_normalize.py
@@ -40,3 +40,11 @@ def test_strips_known_tracking_parameter_names() -> None:
 
 def test_defaults_empty_path_to_root() -> None:
     assert canonicalize_url("https://example.com") == "https://example.com/"
+
+
+def test_preserves_ipv6_brackets_with_non_default_port() -> None:
+    assert canonicalize_url("https://[::1]:8443/path") == "https://[::1]:8443/path"
+
+
+def test_preserves_ipv6_brackets_with_default_port() -> None:
+    assert canonicalize_url("https://[::1]:443/path") == "https://[::1]/path"

--- a/crawler/tests/manifest/test_normalize.py
+++ b/crawler/tests/manifest/test_normalize.py
@@ -1,0 +1,42 @@
+"""Tests for canonical URL derivation."""
+
+from tapio_crawler.manifest.normalize import canonicalize_url
+
+
+def test_lowercases_scheme_and_host() -> None:
+    assert canonicalize_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+
+
+def test_strips_default_port() -> None:
+    assert (
+        canonicalize_url("https://example.com:443/path") == "https://example.com/path"
+    )
+
+
+def test_keeps_non_default_port() -> None:
+    assert (
+        canonicalize_url("https://example.com:8080/path")
+        == "https://example.com:8080/path"
+    )
+
+
+def test_drops_fragment() -> None:
+    assert canonicalize_url("https://example.com/path#section") == (
+        "https://example.com/path"
+    )
+
+
+def test_strips_utm_tracking_parameters() -> None:
+    url = "https://example.com/path?utm_source=x&id=1&utm_campaign=y"
+
+    assert canonicalize_url(url) == "https://example.com/path?id=1"
+
+
+def test_strips_known_tracking_parameter_names() -> None:
+    url = "https://example.com/path?gclid=abc&id=1"
+
+    assert canonicalize_url(url) == "https://example.com/path?id=1"
+
+
+def test_defaults_empty_path_to_root() -> None:
+    assert canonicalize_url("https://example.com") == "https://example.com/"

--- a/crawler/tests/manifest/test_normalize.py
+++ b/crawler/tests/manifest/test_normalize.py
@@ -4,47 +4,49 @@ from tapio_crawler.manifest.normalize import canonicalize_url
 
 
 def test_lowercases_scheme_and_host() -> None:
+    """Scheme and host are lowercased; path casing is preserved."""
     assert canonicalize_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
 
 
 def test_strips_default_port() -> None:
-    assert (
-        canonicalize_url("https://example.com:443/path") == "https://example.com/path"
-    )
+    """The default port for the scheme is stripped from the netloc."""
+    assert canonicalize_url("https://example.com:443/path") == "https://example.com/path"
 
 
 def test_keeps_non_default_port() -> None:
-    assert (
-        canonicalize_url("https://example.com:8080/path")
-        == "https://example.com:8080/path"
-    )
+    """A non-default port is kept in the netloc."""
+    assert canonicalize_url("https://example.com:8080/path") == "https://example.com:8080/path"
 
 
 def test_drops_fragment() -> None:
-    assert canonicalize_url("https://example.com/path#section") == (
-        "https://example.com/path"
-    )
+    """The URL fragment is dropped from the canonical form."""
+    assert canonicalize_url("https://example.com/path#section") == ("https://example.com/path")
 
 
 def test_strips_utm_tracking_parameters() -> None:
+    """Query parameters with a ``utm_`` prefix are removed."""
     url = "https://example.com/path?utm_source=x&id=1&utm_campaign=y"
 
     assert canonicalize_url(url) == "https://example.com/path?id=1"
 
 
 def test_strips_known_tracking_parameter_names() -> None:
+    """Query parameters matching a known tracking name are removed."""
     url = "https://example.com/path?gclid=abc&id=1"
 
     assert canonicalize_url(url) == "https://example.com/path?id=1"
 
 
 def test_defaults_empty_path_to_root() -> None:
+    """A URL with no path canonicalizes to a root path of ``/``."""
     assert canonicalize_url("https://example.com") == "https://example.com/"
 
 
 def test_preserves_ipv6_brackets_with_non_default_port() -> None:
+    """IPv6 host brackets are kept when a non-default port is present."""
     assert canonicalize_url("https://[::1]:8443/path") == "https://[::1]:8443/path"
 
 
 def test_preserves_ipv6_brackets_with_default_port() -> None:
+    """IPv6 host brackets are kept even after the default port is stripped."""
     assert canonicalize_url("https://[::1]:443/path") == "https://[::1]/path"

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -1,0 +1,94 @@
+"""Tests for the SQLite-backed URL manifest store."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from tapio_crawler.manifest.models import ManifestRecord
+from tapio_crawler.manifest.store import ManifestStore
+
+
+def _record(**overrides: object) -> ManifestRecord:
+    now = datetime(2026, 8, 4, tzinfo=UTC)
+    defaults: dict[str, object] = {
+        "site_name": "migri",
+        "source_url": "https://migri.fi/en/page",
+        "canonical_url": "https://migri.fi/en/page",
+        "discovery_source": {"sitemap"},
+        "first_seen_at": now,
+        "last_seen_at": now,
+        "scope_status": "eligible",
+    }
+    defaults.update(overrides)
+    return ManifestRecord(**defaults)
+
+
+@pytest.fixture
+def store(tmp_path) -> ManifestStore:
+    return ManifestStore(tmp_path / "manifest.db")
+
+
+def test_upsert_persists_a_new_record(store: ManifestStore) -> None:
+    store.upsert(_record())
+
+    found = store.get("migri", "https://migri.fi/en/page")
+
+    assert found is not None
+    assert found.discovery_source == {"sitemap"}
+
+
+def test_upsert_merges_discovery_source_provenance(store: ManifestStore) -> None:
+    store.upsert(_record(discovery_source={"sitemap"}))
+    store.upsert(_record(discovery_source={"deep_crawl"}))
+
+    found = store.get("migri", "https://migri.fi/en/page")
+
+    assert found is not None
+    assert found.discovery_source == {"sitemap", "deep_crawl"}
+
+
+def test_upsert_advances_last_seen_at_without_duplicating_rows(
+    store: ManifestStore,
+) -> None:
+    later = datetime(2026, 8, 5, tzinfo=UTC)
+    store.upsert(_record())
+    store.upsert(_record(last_seen_at=later))
+
+    records = store.list_by_site("migri")
+
+    assert len(records) == 1
+    assert records[0].last_seen_at == later
+
+
+def test_upsert_keeps_earlier_sitemap_lastmod_when_not_resupplied(
+    store: ManifestStore,
+) -> None:
+    lastmod = datetime(2026, 1, 1, tzinfo=UTC)
+    store.upsert(_record(sitemap_lastmod=lastmod))
+    store.upsert(_record(sitemap_lastmod=None))
+
+    found = store.get("migri", "https://migri.fi/en/page")
+
+    assert found is not None
+    assert found.sitemap_lastmod == lastmod
+
+
+def test_list_by_site_filters_by_scope_status(store: ManifestStore) -> None:
+    store.upsert(
+        _record(canonical_url="https://migri.fi/en/a", scope_status="eligible")
+    )
+    store.upsert(
+        _record(canonical_url="https://migri.fi/en/b", scope_status="blocked_robots"),
+    )
+
+    eligible = store.list_by_site("migri", scope_status="eligible")
+
+    assert [record.canonical_url for record in eligible] == ["https://migri.fi/en/a"]
+
+
+def test_records_from_different_sites_are_independent(store: ManifestStore) -> None:
+    store.upsert(_record(site_name="migri"))
+    store.upsert(_record(site_name="kela"))
+
+    assert len(store.list_by_site("migri")) == 1
+    assert len(store.list_by_site("kela")) == 1

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -11,6 +11,14 @@ from tapio_crawler.manifest.store import ManifestStore
 
 
 def _record(**overrides: object) -> ManifestRecord:
+    """Build a minimal valid ``ManifestRecord``, overriding any given fields.
+
+    Args:
+        **overrides: Field values to override on top of the defaults.
+
+    Returns:
+        The constructed record.
+    """
     now = datetime(2026, 8, 4, tzinfo=UTC)
     defaults: dict[str, object] = {
         "site_name": "migri",
@@ -27,12 +35,14 @@ def _record(**overrides: object) -> ManifestRecord:
 
 @pytest.fixture
 def store(tmp_path: Path) -> Generator[ManifestStore]:
+    """Yield a ``ManifestStore`` backed by a temporary database file."""
     manifest_store = ManifestStore(tmp_path / "manifest.db")
     yield manifest_store
     manifest_store.close()
 
 
 def test_upsert_persists_a_new_record(store: ManifestStore) -> None:
+    """A first upsert for an identity persists it and it can be read back."""
     store.upsert(_record())
 
     found = store.get("migri", "https://migri.fi/en/page")
@@ -42,6 +52,9 @@ def test_upsert_persists_a_new_record(store: ManifestStore) -> None:
 
 
 def test_upsert_merges_discovery_source_provenance(store: ManifestStore) -> None:
+    """Upserting the same identity accumulates discovery sources rather than
+    replacing them.
+    """
     store.upsert(_record(discovery_source={"sitemap"}))
     store.upsert(_record(discovery_source={"deep_crawl"}))
 
@@ -54,6 +67,9 @@ def test_upsert_merges_discovery_source_provenance(store: ManifestStore) -> None
 def test_upsert_advances_last_seen_at_without_duplicating_rows(
     store: ManifestStore,
 ) -> None:
+    """Re-upserting the same identity updates ``last_seen_at`` in place
+    instead of creating a second row.
+    """
     later = datetime(2026, 8, 5, tzinfo=UTC)
     store.upsert(_record())
     store.upsert(_record(last_seen_at=later))
@@ -67,6 +83,9 @@ def test_upsert_advances_last_seen_at_without_duplicating_rows(
 def test_upsert_keeps_later_last_seen_at_when_replayed_out_of_order(
     store: ManifestStore,
 ) -> None:
+    """Upserting an older ``last_seen_at`` after a newer one does not
+    regress the stored value.
+    """
     earlier = datetime(2026, 8, 3, tzinfo=UTC)
     later = datetime(2026, 8, 5, tzinfo=UTC)
     store.upsert(_record(last_seen_at=later))
@@ -81,6 +100,9 @@ def test_upsert_keeps_later_last_seen_at_when_replayed_out_of_order(
 def test_upsert_keeps_earlier_sitemap_lastmod_when_not_resupplied(
     store: ManifestStore,
 ) -> None:
+    """An upsert without a ``sitemap_lastmod`` value does not clear a
+    previously recorded one.
+    """
     lastmod = datetime(2026, 1, 1, tzinfo=UTC)
     store.upsert(_record(sitemap_lastmod=lastmod))
     store.upsert(_record(sitemap_lastmod=None))
@@ -92,9 +114,8 @@ def test_upsert_keeps_earlier_sitemap_lastmod_when_not_resupplied(
 
 
 def test_list_by_site_filters_by_scope_status(store: ManifestStore) -> None:
-    store.upsert(
-        _record(canonical_url="https://migri.fi/en/a", scope_status="eligible")
-    )
+    """``list_by_site`` with ``scope_status`` returns only matching records."""
+    store.upsert(_record(canonical_url="https://migri.fi/en/a", scope_status="eligible"))
     store.upsert(
         _record(canonical_url="https://migri.fi/en/b", scope_status="blocked_robots"),
     )
@@ -105,6 +126,7 @@ def test_list_by_site_filters_by_scope_status(store: ManifestStore) -> None:
 
 
 def test_records_from_different_sites_are_independent(store: ManifestStore) -> None:
+    """Records for different sites do not collide even with the same URL."""
     store.upsert(_record(site_name="migri"))
     store.upsert(_record(site_name="kela"))
 

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -1,6 +1,8 @@
 """Tests for the SQLite-backed URL manifest store."""
 
+from collections.abc import Generator
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -24,8 +26,10 @@ def _record(**overrides: object) -> ManifestRecord:
 
 
 @pytest.fixture
-def store(tmp_path) -> ManifestStore:
-    return ManifestStore(tmp_path / "manifest.db")
+def store(tmp_path: Path) -> Generator[ManifestStore]:
+    manifest_store = ManifestStore(tmp_path / "manifest.db")
+    yield manifest_store
+    manifest_store.close()
 
 
 def test_upsert_persists_a_new_record(store: ManifestStore) -> None:
@@ -58,6 +62,20 @@ def test_upsert_advances_last_seen_at_without_duplicating_rows(
 
     assert len(records) == 1
     assert records[0].last_seen_at == later
+
+
+def test_upsert_keeps_later_last_seen_at_when_replayed_out_of_order(
+    store: ManifestStore,
+) -> None:
+    earlier = datetime(2026, 8, 3, tzinfo=UTC)
+    later = datetime(2026, 8, 5, tzinfo=UTC)
+    store.upsert(_record(last_seen_at=later))
+    store.upsert(_record(last_seen_at=earlier))
+
+    found = store.get("migri", "https://migri.fi/en/page")
+
+    assert found is not None
+    assert found.last_seen_at == later
 
 
 def test_upsert_keeps_earlier_sitemap_lastmod_when_not_resupplied(

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -53,7 +53,7 @@ def test_discover_reports_summary() -> None:
 
     with (
         patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
-        patch("tapio_crawler.cli.ManifestStore"),
+        patch("tapio_crawler.cli.ManifestStore") as manifest_store_type,
         patch("tapio_crawler.cli.DiscoveryRunner", return_value=runner),
     ):
         config_manager_type.return_value.get_site_config.return_value = site_config
@@ -62,6 +62,7 @@ def test_discover_reports_summary() -> None:
     assert result.exit_code == 0
     assert "complete" in result.stdout
     assert "eligible 1" in result.stdout
+    manifest_store_type.return_value.close.assert_called_once()
 
 
 def test_discover_exits_with_error_on_misconfiguration() -> None:
@@ -73,7 +74,7 @@ def test_discover_exits_with_error_on_misconfiguration() -> None:
 
     with (
         patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
-        patch("tapio_crawler.cli.ManifestStore"),
+        patch("tapio_crawler.cli.ManifestStore") as manifest_store_type,
         patch("tapio_crawler.cli.DiscoveryRunner", return_value=runner),
     ):
         config_manager_type.return_value.get_site_config.return_value = site_config
@@ -81,3 +82,4 @@ def test_discover_exits_with_error_on_misconfiguration() -> None:
 
     assert result.exit_code == 1
     assert "no way to discover" in result.stdout
+    manifest_store_type.return_value.close.assert_called_once()

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -1,12 +1,16 @@
 """Tests for crawler CLI discovery commands."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from tapio_crawler.cli import app, crawl
 from tapio_crawler.config.config_models import SiteConfig
+from tapio_crawler.discovery.runner import (
+    DiscoveryRunSummary,
+    MisconfiguredDiscoveryError,
+)
 
 
 def test_list_sites_displays_configured_sources() -> None:
@@ -31,3 +35,49 @@ def test_crawl_raises_when_the_runner_does_not_provide_a_summary() -> None:
     ):
         config_manager_type.return_value.get_site_config.return_value = site_config
         crawl("example", depth=None, force=False)
+
+
+def test_discover_reports_summary() -> None:
+    site_config = SiteConfig(base_url="https://example.com")
+    summary = DiscoveryRunSummary(
+        run_id="abc",
+        site_name="example",
+        discovered=2,
+        eligible=1,
+        excluded_by_reason={"domain_not_allowed": 1},
+        child_sitemaps_fetched=1,
+        complete=True,
+    )
+    runner = Mock()
+    runner.run = AsyncMock(return_value=summary)
+
+    with (
+        patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
+        patch("tapio_crawler.cli.ManifestStore"),
+        patch("tapio_crawler.cli.DiscoveryRunner", return_value=runner),
+    ):
+        config_manager_type.return_value.get_site_config.return_value = site_config
+        result = CliRunner().invoke(app, ["discover", "example"])
+
+    assert result.exit_code == 0
+    assert "complete" in result.stdout
+    assert "eligible 1" in result.stdout
+
+
+def test_discover_exits_with_error_on_misconfiguration() -> None:
+    site_config = SiteConfig(base_url="https://example.com")
+    runner = Mock()
+    runner.run = AsyncMock(
+        side_effect=MisconfiguredDiscoveryError("no way to discover")
+    )
+
+    with (
+        patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
+        patch("tapio_crawler.cli.ManifestStore"),
+        patch("tapio_crawler.cli.DiscoveryRunner", return_value=runner),
+    ):
+        config_manager_type.return_value.get_site_config.return_value = site_config
+        result = CliRunner().invoke(app, ["discover", "example"])
+
+    assert result.exit_code == 1
+    assert "no way to discover" in result.stdout

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -14,6 +14,7 @@ from tapio_crawler.discovery.runner import (
 
 
 def test_list_sites_displays_configured_sources() -> None:
+    """The ``list-sites`` command prints every configured source site."""
     result = CliRunner().invoke(app, ["list-sites"])
 
     assert result.exit_code == 0
@@ -31,13 +32,14 @@ def test_crawl_raises_when_the_runner_does_not_provide_a_summary() -> None:
     with (
         patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
         patch("tapio_crawler.cli.CrawlerRunner", return_value=runner),
-        pytest.raises(RuntimeError, match="^Crawler finished without a summary\\.$"),
     ):
         config_manager_type.return_value.get_site_config.return_value = site_config
-        crawl("example", depth=None, force=False)
+        with pytest.raises(RuntimeError, match=r"^Crawler finished without a summary\.$"):
+            crawl("example", depth=None, force=False)
 
 
 def test_discover_reports_summary() -> None:
+    """The ``discover`` command prints the run summary on success."""
     site_config = SiteConfig(base_url="https://example.com")
     summary = DiscoveryRunSummary(
         run_id="abc",
@@ -66,11 +68,12 @@ def test_discover_reports_summary() -> None:
 
 
 def test_discover_exits_with_error_on_misconfiguration() -> None:
+    """The ``discover`` command exits with code 1 and the error message when
+    the site has no way to discover URLs.
+    """
     site_config = SiteConfig(base_url="https://example.com")
     runner = Mock()
-    runner.run = AsyncMock(
-        side_effect=MisconfiguredDiscoveryError("no way to discover")
-    )
+    runner.run = AsyncMock(side_effect=MisconfiguredDiscoveryError("no way to discover"))
 
     with (
         patch("tapio_crawler.cli.ConfigManager") as config_manager_type,

--- a/crawler/uv.lock
+++ b/crawler/uv.lock
@@ -1917,6 +1917,7 @@ version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "python-frontmatter" },
     { name = "pyyaml" },
@@ -1937,6 +1938,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "crawl4ai", specifier = ">=0.9.2,<0.10" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },

--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -31,3 +31,97 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = ["integration: test that exercises vector-store integration"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py314"
+
+[tool.ruff.lint]
+select = [
+    "A",     # flake8-builtins
+    "ANN",   # flake8-annotations
+    "ARG",   # flake8-unused-arguments
+    "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "BLE",   # flake8-blind-except
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe complexity
+    "D",     # pydocstyle
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle errors
+    "EM",    # flake8-errmsg
+    "EXE",   # flake8-executable
+    "F",     # pyflakes
+    "FA",    # flake8-future-annotations
+    "FBT",   # flake8-boolean-trap
+    "FIX",   # flake8-fixme
+    "FLY",   # flynt
+    "FURB",  # refurb
+    "G",     # flake8-logging-format
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "ISC",   # flake8-implicit-str-concat
+    "LOG",   # flake8-logging
+    "N",     # pep8-naming
+    "PERF",  # perflint
+    "PGH",   # pygrep-hooks
+    "PIE",   # flake8-pie
+    "PL",    # pylint
+    "PT",    # flake8-pytest-style
+    "PTH",   # flake8-use-pathlib
+    "RET",   # flake8-return
+    "RSE",   # flake8-raise
+    "RUF",   # ruff-specific rules
+    "S",     # flake8-bandit
+    "SIM",   # flake8-simplify
+    "SLF",   # flake8-self
+    "SLOT",  # flake8-slots
+    "T10",   # flake8-debugger
+    "T20",   # flake8-print
+    "TC",    # flake8-type-checking
+    "TD",    # flake8-todos
+    "TID",   # flake8-tidy-imports
+    "TRY",   # tryceratops
+    "UP",    # pyupgrade
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
+]
+ignore = [
+    "ANN401",  # Any is used intentionally for flexible metadata dicts
+    "BLE001",  # broad except-and-log-and-continue is intentional throughout the ingestion pipeline
+    "COM812",  # trailing-comma rules conflict with the ruff formatter
+    "ISC001",  # implicit-str-concat conflicts with the ruff formatter
+    "TC001",   # first-party imports behind TYPE_CHECKING breaks Pydantic runtime introspection
+    "TC002",   # same risk as TC001, for third-party imports
+    "TC003",   # same risk as TC001, for standard-library imports
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "ANN",     # tests are excluded from mypy and don't need type annotations
+    "ARG001",  # unused fixture/mock arguments are normal in tests
+    "ARG002",  # unused mock-override arguments are normal in tests
+    "D",       # docstrings aren't required on test functions
+    "INP001",  # tests intentionally use implicit namespace packages
+    "PLC0415", # local imports for mocking/patching timing are idiomatic in tests
+    "PLR0913", # test functions naturally take many fixture arguments
+    "PLR0917", # mock-heavy test functions naturally have many positional arguments
+    "PLR2004", # magic values in test assertions/fixtures are fine
+    "PT009",   # some test classes intentionally use unittest.TestCase-style assertions
+    "PT019",   # leading-underscore @patch-injected mock parameters aren't pytest fixtures
+    "PTH",     # os.path-based temp file/dir handling in test fixtures is fine
+    "S101",    # assert is the standard pytest idiom
+    "SLF001",  # tests intentionally exercise private members
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pylint]
+max-args = 6
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = ["integration: test that exercises vector-store integration"]
 
 [tool.ruff]

--- a/ingest/tests/conftest.py
+++ b/ingest/tests/conftest.py
@@ -14,9 +14,7 @@ def mock_embeddings():
     embeddings = Mock()
     vector = [0.1] * 384
     embeddings.embed_query.side_effect = lambda _: vector.copy()
-    embeddings.embed_documents.side_effect = lambda texts: [
-        vector.copy() for _ in texts
-    ]
+    embeddings.embed_documents.side_effect = lambda texts: [vector.copy() for _ in texts]
     return embeddings
 
 

--- a/ingest/tests/conftest.py
+++ b/ingest/tests/conftest.py
@@ -1,12 +1,8 @@
 """Ingestion test fixtures."""
 
-import sys
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 @pytest.fixture

--- a/ingest/tests/test_markdown_utils.py
+++ b/ingest/tests/test_markdown_utils.py
@@ -28,9 +28,7 @@ This is test content.
         assert metadata["title"] == "Test Document"
         assert metadata["source_url"] == "https://example.com/page.html"
         assert metadata["url"] == "https://example.com/page.html"
-        assert (
-            content == "# Test Content\n\nThis is test content."
-        )  # No trailing newline
+        assert content == "# Test Content\n\nThis is test content."  # No trailing newline
 
     def test_read_markdown_file_with_source_file(self):
         """Test reading a markdown file with source_file in metadata."""
@@ -48,9 +46,7 @@ This is test content.
         assert metadata["title"] == "Test Document"
         assert metadata["source_file"] == "crawled/example.com/page.html"
         assert metadata["url"] == "example.com/page.html"
-        assert (
-            content == "# Test Content\n\nThis is test content."
-        )  # No trailing newline
+        assert content == "# Test Content\n\nThis is test content."  # No trailing newline
 
     def test_source_file_normalization_only_removes_a_leading_crawled_directory(self):
         mock_file_content = """---
@@ -89,9 +85,7 @@ Content
             # Check that the correct files were found
             assert len(markdown_files) == 2
             assert any(f.endswith("file1.md") for f in markdown_files)
-            assert any(
-                f.endswith(os.path.join("subdir", "file3.md")) for f in markdown_files
-            )
+            assert any(f.endswith(os.path.join("subdir", "file3.md")) for f in markdown_files)
             assert not any(f.endswith("file2.txt") for f in markdown_files)
 
     def test_find_markdown_files_with_site_filter(self):


### PR DESCRIPTION
## Description

Implements Phase 1 of [docs/specs/crawler-improvements.md](docs/specs/crawler-improvements.md) — the "inventory foundation" slice agreed with the maintainer: a durable URL manifest, sitemap-first discovery with per-URL `lastmod`, source scope configuration, and bounded gap-crawl discovery for the one source without a sitemap.

### What's included

- **Config schema**: `PolitenessConfig`, `DiscoveryConfig`, `ScopeConfig`, `GapCrawlConfig` added to `CrawlerConfig`, all with safe defaults. All 5 sources (migri, dvv, kela, vero, tyomarkkinatori) configured: sitemap-first discovery for the first 4, bounded gap-crawl for tyomarkkinatori (no sitemap exists).
- **Robots + rate limiting**: fail-closed `robots.txt` handling (`RobotsRules`) wrapping stdlib `RobotFileParser`, which fails open by default. `HostRateLimiter` shared across every discovery-time request type, enforcing a source's `Crawl-delay` as a floor and treating `429`/`503` `Retry-After` as a per-host suspension.
- **URL manifest**: SQLite-backed `ManifestStore` with `ManifestRecord` schema per the spec's manifest table. Canonical URL derivation (`canonicalize_url`) strips scheme/host casing, default ports, fragments, and known tracking params for dedup identity.
- **Discovery mechanisms**:
  - `evaluate_scope()` — domain/path eligibility (content-type/language deferred to render time).
  - `discover_sitemap_urls()` — a custom sitemap fetcher/parser (httpx + `ElementTree`) rather than Crawl4AI's `AsyncUrlSeeder`, since the installed version doesn't expose a per-URL `lastmod`. Follows one level of sitemap-index nesting and marks a run incomplete on any fetch/parse failure.
  - `discover_via_gap_crawl()` — bounded BFS deep-crawl discovery for sources with no sitemap.
- **`DiscoveryRunner`**: dispatches sitemap vs. gap-crawl discovery per site, resolves the effective per-host delay from `Crawl-delay`, scores each discovered URL, and upserts a `ManifestRecord`. Raises `MisconfiguredDiscoveryError` if a source has neither a sitemap nor gap-crawl enabled. Returns a `DiscoveryRunSummary` (discovered/eligible/excluded-by-reason/child-sitemaps-fetched counts).
- **CLI**: new `discover <site>` command mirroring the existing `crawl` command's structure and output style.

### Explicitly out of scope for this PR

Per the agreed Phase 1 boundary: resumable rendering, artifact rekeying to canonical URL, cache/refresh policy and `trust_lastmod` promotion, gap-crawl-as-supplement for sitemap-having sources, retrieval evaluation, operator controls (pause/cancel/concurrent jobs), and all P2 items from the spec.

### Also fixed

- `.gitignore`'s bare `MANIFEST` entry (for setuptools' packaging artifact) was matching any path containing "manifest" case-insensitively on macOS, silently hiding the new `manifest/` packages from `git status`. Anchored it to the repo root.

## Checklist

- [x] I ran the relevant service test suite(s) and all tests pass
- [x] I ran `uv run ruff check .` in `crawler/` and addressed any issues
- [x] I ran the package-local mypy and Pyrefly commands documented in `CONTRIBUTING.md` and addressed any issues
- [x] New/changed code meets the project's 80% coverage guideline (95% for `crawler/tapio_crawler`, `uv run pytest --cov=tapio_crawler`)
- [x] I updated `README.md` if this PR changes user-facing behavior — not yet done; happy to add `discover` command docs if desired

## Related issue

Relates to the "Phase 1 — inventory foundation" requirements in docs/specs/crawler-improvements.md (#73).

## Additional context

77 tests pass across `crawler/tests`, 95% coverage on `tapio_crawler`. Scope was deliberately narrowed from the full 5-phase spec via a short back-and-forth with the maintainer before implementation began; see the commit sequence for a phase-by-phase breakdown (config schema → robots/rate-limiter → manifest store → discovery mechanisms → runner → CLI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `discover` command for cataloging site URLs without rendering pages or generating content.
  * Added sitemap discovery, nested sitemap support, last-modified dates, and bounded crawling for sites without sitemaps.
  * Added robots.txt compliance, crawl-delay handling, retry throttling, URL scope filtering, and configurable discovery policies.
  * Added durable URL inventory storage with canonicalized URLs and discovery metadata.

* **Bug Fixes**
  * Improved handling of unavailable robots files, failed requests, malformed sitemaps, and discovery misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->