### PR TITLE
Add Phase 2 crawler rendering: manifest-driven, resumable, per-document refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ ollama pull gemma4:latest
 Run these commands from the repository root, in this order:
 
 ```bash
-# 1. Crawl every configured site using its configured depth, limits, and schedule.
+# 1. Discover each site's URL inventory, then render what's due into content/.
 mise run crawl
 
 # 2. Chunk and embed the Markdown written to content/.
@@ -98,9 +98,10 @@ mise run backend
 mise run app
 ```
 
-The crawler respects each site's `recrawl_interval_hours`; a site that is not
-due is skipped. It attempts every configured site even if an earlier one fails,
-then returns a non-zero status if any site failed. When new pages are crawled,
+For each configured site, `mise run crawl` runs `discover` (populating its URL
+manifest) and then `crawl` (rendering only manifest records that are due - see
+`crawler/README.md`). It attempts every configured site even if an earlier one
+fails, then returns a non-zero status if any site failed. When new pages are crawled,
 rerun `mise run ingest`, then restart the backend (`backend/` is what reads
 `vectorstore/`; the SvelteKit `app/` only calls the backend's API) so it opens
 the refreshed vector collection.
@@ -121,7 +122,7 @@ files only; they do not import, invoke, or otherwise depend on one another.
 
 | Command | Purpose |
 | --- | --- |
-| `mise run crawl` | Crawl every configured site with its configured settings; attempt all sites before reporting failures. |
+| `mise run crawl` | Discover, then render, every configured site; attempt all sites before reporting failures. |
 | `mise run ingest` | Ingest all crawler Markdown from `content/` into `vectorstore/`. |
 | `mise run backend` | Start the FastAPI backend, which reads `vectorstore/`. |
 | `mise run app` | Start the SvelteKit chat client's dev server. |
@@ -144,7 +145,8 @@ single-site crawl or a shallow smoke test, use the crawler CLI directly:
 ```bash
 cd crawler
 uv run tapio-crawler list-sites
-uv run tapio-crawler crawl migri --depth 0
+uv run tapio-crawler discover migri
+uv run tapio-crawler crawl migri --max-urls 5
 ```
 
 Then return to the repository root and run `mise run ingest -- --site migri`.

--- a/crawler/README.md
+++ b/crawler/README.md
@@ -11,34 +11,11 @@ directory. Locally this defaults to the repository's `content/` directory; in
 deployment, mount the same directory into both services and set
 `TAPIO_CONTENT_DIR` to its mount path.
 
-Collect a configured site directly into `{TAPIO_CONTENT_DIR}/{site}/parsed/`
-Markdown:
-
-```bash
-uv run tapio-crawler crawl migri
-```
-
-Use `--depth 0` for a single-page smoke test. Each saved document includes
-`title`, `source_url`, and `crawl_timestamp` YAML frontmatter for ingestion.
-
-## Polite re-crawls
-
-Each site is crawled at most once every 30 days by default
-(`recrawl_interval_hours: 720`), with a per-site override in
-`tapio_crawler/config/site_configs.yaml`. A successful crawl records its time
-in `{TAPIO_CONTENT_DIR}/{site}/crawl_state.json`; use `--force` only when an immediate
-refresh is needed.
-
-When a site is due, Crawl4AI stores its persistent cache in
-`{TAPIO_CONTENT_DIR}/.crawl4ai/` and uses conditional freshness checks (`ETag`/
-`Last-Modified`) before rendering a cached page again. Mount `content/` as a
-persistent volume in deployment, or set `CRAWL4_AI_BASE_DIRECTORY` to another
-persistent location.
-
 ## URL discovery and the manifest
 
-`discover` builds a site's URL inventory - separately from crawling and
-rendering - and records it in a durable, SQLite-backed manifest:
+`discover` builds a site's URL inventory and records it in a durable,
+SQLite-backed manifest. Run this first for a site before `crawl` - rendering
+reads only from the manifest, it does not discover URLs on its own:
 
 ```bash
 uv run tapio-crawler discover migri
@@ -55,4 +32,36 @@ upserted into the manifest with its eligibility.
 
 The manifest lives at `{TAPIO_CONTENT_DIR}/manifest.db` by default; override
 its path with `TAPIO_MANIFEST_PATH`. A discovery run never renders pages or
-writes Markdown - that remains `crawl`'s job.
+writes Markdown - that's `crawl`'s job.
+
+## Rendering: manifest-driven, resumable collection
+
+`crawl` renders every manifest record that is due, into
+`{TAPIO_CONTENT_DIR}/{site}/parsed/` Markdown:
+
+```bash
+uv run tapio-crawler crawl migri
+```
+
+A record is due on its first render, when its source's `discovery.trust_lastmod`
+is `true` and the sitemap `lastmod` is newer than the last render, when it was
+last rendered under an older extractor version, or once
+`refresh.unchanged_audit_days` (default 90) has elapsed since its last check.
+`--force` ignores that schedule and re-renders every eligible record.
+`--max-urls` (default 5000) caps how many records one run processes;
+`--batch-size` (default 500) is the manifest page size used while selecting
+them. Progress is saved to the manifest after each record completes, so a
+stopped run resumes from where it left off on the next invocation rather than
+starting over.
+
+Each saved document includes `title`, `source_url`, `canonical_url`,
+`content_hash`, `language`, `extractor_version`, and `crawl_timestamp` YAML
+frontmatter. Artifacts are keyed by `canonical_url`, not the URL as
+discovered, so redirects and tracking-parameter variants of the same page
+share one file.
+
+Crawl4AI stores its persistent HTTP cache in `{TAPIO_CONTENT_DIR}/.crawl4ai/`
+and uses conditional freshness checks (`ETag`/`Last-Modified`) before
+re-rendering a page whose scheduled check finds it unchanged. Mount `content/`
+as a persistent volume in deployment, or set `CRAWL4_AI_BASE_DIRECTORY` to
+another persistent location.

--- a/crawler/tapio_crawler/cli.py
+++ b/crawler/tapio_crawler/cli.py
@@ -22,38 +22,52 @@ def list_sites() -> None:
 @app.command()
 def crawl(
     site: str,
-    depth: int | None = typer.Option(None, "--depth", "-d"),
-    force: bool = typer.Option(False, "--force", help="Ignore the re-crawl interval."),
+    max_urls: int = typer.Option(
+        5_000,
+        "--max-urls",
+        help="Hard cap on manifest records rendered this run.",
+    ),
+    batch_size: int = typer.Option(
+        500,
+        "--batch-size",
+        help="Manifest page size used while selecting due records.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Ignore each record's refresh schedule and render every eligible record.",
+    ),
 ) -> None:
-    """Collect source pages into Markdown for one configured site."""
+    """Render due manifest records into Markdown for one configured site.
+
+    Run ``discover <site>`` first to populate the manifest this command reads
+    from.
+    """
     config = ConfigManager()
     site_config = config.get_site_config(site)
-    if depth is not None:
-        site_config.crawler_config.max_depth = depth
-    runner = CrawlerRunner()
-    results = runner.run(site, site_config, force=force)
-    summary = runner.last_summary
-    if summary is None:
-        msg = "Crawler finished without a summary."
-        raise RuntimeError(msg)
-    if summary.get("skipped"):
-        typer.echo(
-            f"Skipped {site}; it was crawled within its "
-            f"{site_config.crawler_config.recrawl_interval_hours}-hour interval. "
-            "Use --force to crawl it now.",
-        )
-        return
-    status_codes = ", ".join(f"{status}={count}" for status, count in summary.get("status_codes", {}).items()) or "none"
-    cache_statuses = (
-        ", ".join(f"{status}={count}" for status, count in summary.get("cache_statuses", {}).items()) or "none"
-    )
+    store = ManifestStore()
+    try:
+        runner = CrawlerRunner(store)
+        summary = runner.run(site, site_config, max_urls=max_urls, batch_size=batch_size, force=force)
+    finally:
+        store.close()
+
+    status = "complete" if summary.complete else "incomplete"
+    status_codes = ", ".join(f"{code}={count}" for code, count in summary.status_codes.items()) or "none"
+    cache_statuses = ", ".join(f"{status_}={count}" for status_, count in summary.cache_statuses.items()) or "none"
     typer.echo(
-        f"Wrote {len(results)} Markdown documents for {site}. "
-        f"Fetched {summary.get('fetched', 0)}; failed {summary.get('failed', 0)}; "
-        f"near-empty {summary.get('near_empty', 0)}; "
-        f"fallback recoveries {summary.get('fallback_recoveries', 0)}; "
+        f"Render run {summary.run_id} for {site}: {status}. "
+        f"Considered {summary.considered}; rendered {summary.rendered}; saved {summary.saved}; "
+        f"low-quality {summary.low_quality}; failed {summary.failed}; retried {summary.retried}; "
+        f"coverage {summary.coverage_percent:.1f}% ({summary.current_total}/{summary.eligible_total}). "
         f"HTTP statuses: {status_codes}; cache: {cache_statuses}.",
     )
+    coverage_target = site_config.crawler_config.refresh.coverage_target_percent
+    if summary.coverage_percent < coverage_target:
+        typer.echo(
+            f"WARNING: coverage {summary.coverage_percent:.1f}% is below the "
+            f"{coverage_target:.1f}% target configured for {site}.",
+        )
 
 
 @app.command()

--- a/crawler/tapio_crawler/config/config_models.py
+++ b/crawler/tapio_crawler/config/config_models.py
@@ -36,6 +36,10 @@ class DiscoveryConfig(BaseModel):
     source: Literal["sitemap", "none"] = "none"
     # Empty: read ``Sitemap:`` entries from the source's robots.txt instead.
     sitemap_urls: list[str] = Field(default_factory=list)
+    # Whether sitemap lastmod may trigger a re-render (Requirement 5). Stays
+    # False until a source's lastmod is empirically shown to correlate with
+    # real content changes, per docs/specs/crawler-improvements.md.
+    trust_lastmod: bool = False
 
 
 class ScopeConfig(BaseModel):
@@ -58,17 +62,23 @@ class GapCrawlConfig(BaseModel):
     max_pages: Annotated[int, Field(ge=1, le=1_000)] = 100
 
 
+class RefreshConfig(BaseModel):
+    """Per-document refresh scheduling and coverage targets for one source."""
+
+    unchanged_audit_days: Annotated[int, Field(ge=1)] = 90
+    inactive_grace_cycles: Annotated[int, Field(ge=1)] = 2
+    coverage_target_percent: Annotated[float, Field(ge=0.0, le=100.0)] = 95.0
+
+
 class CrawlerConfig(BaseModel):
     """Bounded, polite settings for a site's Crawl4AI job."""
 
-    max_depth: Annotated[int, Field(ge=0, le=10)] = 1
-    max_pages: Annotated[int, Field(ge=1, le=1_000)] = 50
     page_timeout: Annotated[int, Field(ge=1, le=120)] = 30
     min_delay: Annotated[float, Field(ge=0.0)] = 1.0
     max_delay: Annotated[float, Field(ge=0.0)] = 3.0
     max_concurrent: Annotated[int, Field(ge=1, le=20)] = 3
-    recrawl_interval_hours: Annotated[int, Field(ge=1, le=8_760)] = 720
     minimum_content_length: Annotated[int, Field(ge=1)] = 100
+    word_count_threshold: Annotated[int, Field(ge=0)] = 20
     css_selector: str | None = None
     target_elements: list[str] = Field(default_factory=list)
     remove_consent_popups: bool = False
@@ -79,6 +89,7 @@ class CrawlerConfig(BaseModel):
     discovery: DiscoveryConfig = Field(default_factory=DiscoveryConfig)
     scope: ScopeConfig = Field(default_factory=ScopeConfig)
     gap_crawl: GapCrawlConfig = Field(default_factory=GapCrawlConfig)
+    refresh: RefreshConfig = Field(default_factory=RefreshConfig)
 
     @model_validator(mode="after")
     def validate_delay_range(self) -> CrawlerConfig:

--- a/crawler/tapio_crawler/config/config_models.py
+++ b/crawler/tapio_crawler/config/config_models.py
@@ -63,7 +63,20 @@ class GapCrawlConfig(BaseModel):
 
 
 class RefreshConfig(BaseModel):
-    """Per-document refresh scheduling and coverage targets for one source."""
+    """Per-document refresh scheduling and coverage targets for one source.
+
+    Attributes:
+        unchanged_audit_days: How many days a rendered document may go
+            without a fresh check before it becomes due again for a
+            scheduled audit, even without a signal that it changed.
+        inactive_grace_cycles: How many consecutive discovery runs a
+            previously eligible URL may go missing before it is treated as
+            removed from the source, rather than a transient omission.
+        coverage_target_percent: The share of eligible URLs, 0-100, that
+            should have a successful current document before a render run
+            is considered to have met its coverage target; used only to
+            flag a shortfall in run output, not to gate anything.
+    """
 
     unchanged_audit_days: Annotated[int, Field(ge=1)] = 90
     inactive_grace_cycles: Annotated[int, Field(ge=1)] = 2

--- a/crawler/tapio_crawler/config/site_configs.yaml
+++ b/crawler/tapio_crawler/config/site_configs.yaml
@@ -7,9 +7,6 @@ sites:
     base_url: "https://migri.fi"
     description: "Finnish Immigration Service website"
     crawler_config:
-      max_depth: 1
-      max_pages: 50
-      recrawl_interval_hours: 720
       # migri.fi's robots.txt declares a 5s Crawl-delay; this is the floor
       # under which the shared rate limiter will never schedule a request.
       min_delay: 5.0
@@ -39,9 +36,6 @@ sites:
     base_url: "https://tyomarkkinatori.fi/"
     description: "Work assistance and employment services website"
     crawler_config:
-      max_depth: 1
-      max_pages: 50
-      recrawl_interval_hours: 720
       min_delay: 1.5
       max_delay: 3.0
       max_concurrent: 3
@@ -75,9 +69,6 @@ sites:
     base_url: "https://www.kela.fi"
     description: "Kela (Social Insurance Institution of Finland) website"
     crawler_config:
-      max_depth: 1
-      max_pages: 50
-      recrawl_interval_hours: 720
       min_delay: 1.2
       max_delay: 3.0
       max_concurrent: 4
@@ -103,9 +94,6 @@ sites:
     base_url: "https://www.vero.fi/en/"
     description: "Vero (Guidance about taxation in Finland) website"
     crawler_config:
-      max_depth: 1
-      max_pages: 50
-      recrawl_interval_hours: 720
       min_delay: 1.0
       max_delay: 3.0
       max_concurrent: 4
@@ -132,9 +120,6 @@ sites:
     base_url: "https://dvv.fi/"
     description: "DVV (Digital and population data services agency) website"
     crawler_config:
-      max_depth: 1
-      max_pages: 50
-      recrawl_interval_hours: 720
       # dvv.fi's robots.txt declares a 5s Crawl-delay; see migri above.
       min_delay: 5.0
       max_delay: 8.0

--- a/crawler/tapio_crawler/crawler/crawler.py
+++ b/crawler/tapio_crawler/crawler/crawler.py
@@ -1,13 +1,26 @@
-"""Crawl4AI-backed crawler that writes RAG-ready Markdown documents."""
+"""Crawl4AI-backed renderer that turns due manifest records into Markdown.
 
+Manifest-driven, per-URL rendering (Phase 2 of
+docs/specs/crawler-improvements.md): ``discover`` populates the manifest,
+this module consumes it. Unlike Phase 1's discovery (which reuses Crawl4AI's
+``arun_many`` for a single-config batch), rendering calls ``arun()`` once per
+URL under a bounded semaphore, because Requirement 5 needs a different
+``CacheMode`` per record - something ``arun_many`` can't express with one
+shared config for a whole batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
 import hashlib
-import json
 import logging
 import os
 import re
+import uuid
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import NotRequired, TypedDict, cast
+from typing import cast
 from urllib.parse import urlparse
 
 import frontmatter
@@ -18,6 +31,19 @@ from tapio_crawler.config.settings import (
     DEFAULT_CRAWL4AI_BASE_DIRECTORY,
     DEFAULT_DIRS,
 )
+from tapio_crawler.crawler.policy import (
+    EXTRACTOR_VERSION,
+    MAX_RETRY_COUNT,
+    RenderDecision,
+    decide_render,
+    retry_backoff_seconds,
+)
+from tapio_crawler.discovery.rate_limiter import HostRateLimiter, resolve_effective_delay
+from tapio_crawler.discovery.robots import fetch_robots_rules
+from tapio_crawler.discovery.scope import evaluate_scope
+from tapio_crawler.manifest.models import ManifestRecord
+from tapio_crawler.manifest.normalize import canonicalize_url
+from tapio_crawler.manifest.store import ManifestStore
 
 # Crawl4AI reads this when its database module is imported. This default keeps
 # cache entries durable alongside the crawler's Markdown output, while allowing
@@ -26,67 +52,388 @@ os.environ.setdefault("CRAWL4_AI_BASE_DIRECTORY", DEFAULT_CRAWL4AI_BASE_DIRECTOR
 
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
 from crawl4ai.content_filter_strategy import PruningContentFilter
-from crawl4ai.deep_crawling import BFSDeepCrawlStrategy
 from crawl4ai.markdown_generation_strategy import DefaultMarkdownGenerator
 from crawl4ai.models import CrawlResult as Crawl4AIResult
-from crawl4ai.models import CrawlResultContainer
 
 logger = logging.getLogger(__name__)
 
 EXCLUDED_TAGS = ["nav", "header", "footer", "form"]
+TOO_MANY_REQUESTS_STATUS = 429
+SERVICE_UNAVAILABLE_STATUS = 503
 
 
-class CrawlResult(TypedDict):
-    """A successfully saved Markdown document."""
+@dataclass
+class RenderRunSummary:
+    """Counts describing one render run, for the run's report/log line.
 
-    source_url: str
-    output_file: str
-    title: str
-    markdown_length: int
-    depth: int
-    crawl_timestamp: str
-    status_code: NotRequired[int | None]
+    Attributes:
+        run_id: Unique identifier for this render run.
+        site_name: Name of the configured source site.
+        considered: Number of eligible manifest records evaluated for due-ness.
+        skipped_not_due: Eligible records that were not due this run.
+        rendered: Number of records for which a Crawl4AI ``arun()`` completed.
+        saved: Number of records for which a Markdown document was written.
+        low_quality: Renders whose cleaned Markdown was below the minimum
+            content length and required a fallback retry.
+        failed: Renders that failed outright (network error, non-2xx, or an
+            unrecoverable low-quality result).
+        retried: Renders that were scheduled for a future retry (failure or
+            an unconfirmed cache-validation fallback).
+        complete: Whether the run finished without a fatal interruption.
+        eligible_total: Total eligible manifest records for this site, as of
+            run completion.
+        current_total: Eligible records with a successful current document,
+            as of run completion.
+    """
 
+    run_id: str
+    site_name: str
+    considered: int = 0
+    skipped_not_due: int = 0
+    rendered: int = 0
+    saved: int = 0
+    low_quality: int = 0
+    failed: int = 0
+    retried: int = 0
+    status_codes: dict[str, int] = field(default_factory=dict)
+    cache_statuses: dict[str, int] = field(default_factory=dict)
+    complete: bool = True
+    eligible_total: int = 0
+    current_total: int = 0
 
-class CrawlSummary(TypedDict):
-    """Counters describing a completed crawl, including discarded results."""
-
-    fetched: int
-    saved: int
-    failed: int
-    near_empty: int
-    fallback_retries: int
-    fallback_recoveries: int
-    status_codes: dict[str, int]
-    cache_statuses: dict[str, int]
-    skipped: bool
+    @property
+    def coverage_percent(self) -> float:
+        """Return the share of eligible URLs with a successful current document."""
+        if self.eligible_total == 0:
+            return 100.0
+        return 100.0 * self.current_total / self.eligible_total
 
 
 class Crawl4AICrawler:
-    """Collect one site with automatic content pruning and bounded traversal."""
+    """Render due manifest records for one site into Markdown documents."""
 
-    def __init__(self, site_name: str, site_config: SiteConfig) -> None:
-        """Initialize a crawler for one configured site.
+    def __init__(
+        self,
+        site_name: str,
+        site_config: SiteConfig,
+        manifest_store: ManifestStore,
+    ) -> None:
+        """Initialize a renderer for one configured site.
 
         Args:
-            site_name: Identifier used for output and crawl state paths.
+            site_name: Identifier used for output paths and manifest lookups.
             site_config: Site-specific collection and extraction settings.
+            manifest_store: Store holding this site's discovered URL inventory.
         """
         self.site_name = site_name
         self.site_config = site_config
         self.config = site_config.crawler_config
+        self.manifest_store = manifest_store
         self.output_dir = Path(DEFAULT_CONTENT_DIR) / site_name / DEFAULT_DIRS["PARSED_DIR"]
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        self.state_path = self.output_dir.parent / "crawl_state.json"
-        self.summary: CrawlSummary = self._empty_summary()
 
-    def _run_config(
+    async def crawl(
         self,
         *,
-        deep_crawl: bool = True,
-        apply_content_cleanup: bool = True,
-        cache_mode: CacheMode = CacheMode.ENABLED,
-    ) -> CrawlerRunConfig:
+        max_urls: int,
+        batch_size: int,
+        force: bool = False,
+    ) -> RenderRunSummary:
+        """Render every due manifest record for this site, up to ``max_urls``.
+
+        Args:
+            max_urls: Hard cap on the number of records rendered this run.
+            batch_size: Manifest page size used while selecting due records.
+            force: Ignore each record's refresh schedule and render every
+                eligible record.
+
+        Returns:
+            A summary of counts and completeness for this run.
+        """
+        summary = RenderRunSummary(run_id=str(uuid.uuid4()), site_name=self.site_name)
+
+        base_url = str(self.site_config.base_url).rstrip("/")
+        robots = await fetch_robots_rules(base_url, self.config.politeness.user_agent)
+        if not robots.reachable and self.config.robots_policy == "require":
+            summary.complete = False
+            logger.warning(
+                "robots.txt unreachable for %s; marking render run incomplete",
+                self.site_name,
+            )
+            return summary
+
+        rate_limiter = HostRateLimiter(min_delay=self.config.min_delay, max_delay=self.config.max_delay)
+        effective_delay = resolve_effective_delay(
+            configured_min_delay=self.config.min_delay,
+            configured_max_delay=self.config.max_delay,
+            crawl_delay=robots.crawl_delay if self.config.politeness.respect_crawl_delay else None,
+        )
+        rate_limiter.min_delay = effective_delay.min_delay
+        rate_limiter.max_delay = effective_delay.max_delay
+
+        due = self._select_due_records(max_urls=max_urls, batch_size=batch_size, force=force, summary=summary)
+        if due:
+            semaphore = asyncio.Semaphore(self.config.max_concurrent)
+            try:
+                async with AsyncWebCrawler(config=self._browser_config()) as crawler:
+                    await asyncio.gather(
+                        *(
+                            self._render_bounded(crawler, record, decision, rate_limiter, semaphore, summary)
+                            for record, decision in due
+                        ),
+                    )
+            except Exception:
+                logger.exception("Render run failed for %s", self.site_name)
+                summary.complete = False
+
+        self._finalize_coverage(summary)
+        logger.info("Render summary for %s: %s", self.site_name, summary)
+        return summary
+
+    def _select_due_records(
+        self,
+        *,
+        max_urls: int,
+        batch_size: int,
+        force: bool,
+        summary: RenderRunSummary,
+    ) -> list[tuple[ManifestRecord, RenderDecision]]:
+        """Page through eligible manifest records and select the due ones.
+
+        Stops once the site's eligible set is exhausted or ``max_urls`` due
+        records have been collected, whichever comes first.
+        """
+        due: list[tuple[ManifestRecord, RenderDecision]] = []
+        now = datetime.now(UTC)
+        after = ""
+        while len(due) < max_urls:
+            page = self.manifest_store.list_eligible_page(
+                self.site_name,
+                after_canonical_url=after,
+                limit=batch_size,
+            )
+            if not page:
+                break
+            for record in page:
+                summary.considered += 1
+                decision = decide_render(
+                    record,
+                    trust_lastmod=self.config.discovery.trust_lastmod,
+                    unchanged_audit_days=self.config.refresh.unchanged_audit_days,
+                    now=now,
+                    force=force,
+                )
+                if decision is None:
+                    summary.skipped_not_due += 1
+                    continue
+                due.append((record, decision))
+                if len(due) >= max_urls:
+                    break
+            after = page[-1].canonical_url
+            if len(page) < batch_size:
+                break
+        return due
+
+    async def _render_bounded(
+        self,
+        crawler: AsyncWebCrawler,
+        record: ManifestRecord,
+        decision: RenderDecision,
+        rate_limiter: HostRateLimiter,
+        semaphore: asyncio.Semaphore,
+        summary: RenderRunSummary,
+    ) -> None:
+        """Render one record under the run's concurrency limit."""
+        async with semaphore:
+            await self._render_one(crawler, record, decision, rate_limiter, summary)
+
+    async def _render_one(
+        self,
+        crawler: AsyncWebCrawler,
+        record: ManifestRecord,
+        decision: RenderDecision,
+        rate_limiter: HostRateLimiter,
+        summary: RenderRunSummary,
+    ) -> None:
+        """Render one manifest record and persist its outcome immediately.
+
+        Persisting here - rather than batching updates until the whole run
+        finishes - is what makes a stopped run resumable: whatever records
+        already completed are already saved to the manifest.
+        """
+        await rate_limiter.wait_for_turn()
+        now = datetime.now(UTC)
+        run_config = self._run_config(cache_mode=decision.cache_mode)
+        try:
+            results = await crawler.arun(record.source_url, config=run_config)
+            raw_result = cast("Crawl4AIResult", next(iter(results)))
+        except Exception:
+            logger.exception("Render failed for %s", record.source_url)
+            self._save_failure(record, now, summary)
+            return
+
+        self._record_status(raw_result, summary)
+        summary.rendered += 1
+
+        if not raw_result.success:
+            self._handle_failure(record, raw_result, now, summary, rate_limiter)
+            return
+
+        cache_status = str(getattr(raw_result, "cache_status", None) or "miss")
+        if cache_status == "hit_validated":
+            self._handle_confirmed(record, now)
+        elif cache_status == "hit_fallback":
+            self._handle_unconfirmed(record, now, summary)
+        else:
+            await self._handle_fresh_fetch(crawler, record, raw_result, now, summary)
+
+    async def _handle_fresh_fetch(
+        self,
+        crawler: AsyncWebCrawler,
+        record: ManifestRecord,
+        raw_result: Crawl4AIResult,
+        now: datetime,
+        summary: RenderRunSummary,
+    ) -> None:
+        """Handle a real fetch (``cache_status == "miss"``): save or retry."""
+        markdown = self._markdown(raw_result)
+        if len(markdown.strip()) < self.config.minimum_content_length:
+            summary.low_quality += 1
+            fallback_result = await self._fallback_result(crawler, record.source_url)
+            markdown = self._markdown(fallback_result)
+            if not fallback_result.success or len(markdown.strip()) < self.config.minimum_content_length:
+                logger.warning("Skipping unrecoverable near-empty result for %s", record.source_url)
+                summary.failed += 1
+                self._save_failure(record, now, summary)
+                return
+            raw_result = fallback_result
+
+        final_url = str((raw_result.metadata or {}).get("url") or raw_result.url)
+        resolved_canonical = canonicalize_url(final_url)
+        content_hash = hashlib.sha256(markdown.encode("utf-8")).hexdigest()
+        title = str((raw_result.metadata or {}).get("title") or "Untitled document")
+
+        base_update = {
+            "source_url": final_url,
+            "canonical_url": resolved_canonical,
+            "fetch_status": "success",
+            "validation_status": "rendered",
+            "last_attempt_at": now,
+            "last_rendered_at": now,
+            "extractor_version": EXTRACTOR_VERSION,
+            "content_hash": content_hash,
+            "content_length": len(markdown),
+            "title": title,
+            "language": self._language(),
+            "retry_count": 0,
+            "retry_after": None,
+        }
+
+        if resolved_canonical != record.canonical_url:
+            decision = evaluate_scope(final_url, self.config.scope)
+            if not decision.eligible:
+                logger.warning(
+                    "Redirect target %s for %s is out of scope; discarding",
+                    final_url,
+                    record.source_url,
+                )
+                summary.failed += 1
+                self._save_failure(record, now, summary)
+                return
+            new_record = record.model_copy(update=base_update)
+            self.manifest_store.rekey(self.site_name, record.canonical_url, new_record)
+            old_path = self.output_dir / self._filename(record.canonical_url)
+            old_path.unlink(missing_ok=True)
+            self._write_document(new_record, markdown)
+        else:
+            updated = record.model_copy(update=base_update)
+            self.manifest_store.save(updated)
+            self._write_document(updated, markdown)
+
+        summary.saved += 1
+
+    def _handle_failure(
+        self,
+        record: ManifestRecord,
+        raw_result: Crawl4AIResult,
+        now: datetime,
+        summary: RenderRunSummary,
+        rate_limiter: HostRateLimiter,
+    ) -> None:
+        """Record a render failure and extend the host suspension on 429/503."""
+        summary.failed += 1
+        status_code = getattr(raw_result, "status_code", None)
+        if status_code in (TOO_MANY_REQUESTS_STATUS, SERVICE_UNAVAILABLE_STATUS):
+            headers = getattr(raw_result, "response_headers", None) or {}
+            rate_limiter.suspend_for_retry_after(headers.get("Retry-After"))
+        self._save_failure(record, now, summary)
+
+    def _save_failure(self, record: ManifestRecord, now: datetime, summary: RenderRunSummary) -> None:
+        """Persist a failed attempt with exponential backoff, capped at ``MAX_RETRY_COUNT``."""
+        retry_count, retry_after = self._next_retry(record, now, summary)
+        updated = record.model_copy(
+            update={
+                "fetch_status": "failed",
+                "last_attempt_at": now,
+                "retry_count": retry_count,
+                "retry_after": retry_after,
+            },
+        )
+        self.manifest_store.save(updated)
+
+    @staticmethod
+    def _next_retry(
+        record: ManifestRecord,
+        now: datetime,
+        summary: RenderRunSummary,
+    ) -> tuple[int, datetime | None]:
+        """Return the next retry count/timestamp for a failed or unconfirmed attempt.
+
+        Counts it in ``summary.retried`` only when a future retry is actually
+        scheduled (the cap isn't exceeded).
+        """
+        retry_count = record.retry_count + 1
+        if retry_count > MAX_RETRY_COUNT:
+            return retry_count, None
+        summary.retried += 1
+        return retry_count, now + timedelta(seconds=retry_backoff_seconds(retry_count))
+
+    def _handle_confirmed(self, record: ManifestRecord, now: datetime) -> None:
+        """Persist an HTTP-confirmed-fresh cache hit, without a browser render."""
+        updated = record.model_copy(
+            update={
+                "validation_status": "confirmed",
+                "fetch_status": "success",
+                "last_attempt_at": now,
+                "retry_count": 0,
+                "retry_after": None,
+            },
+        )
+        self.manifest_store.save(updated)
+
+    def _handle_unconfirmed(self, record: ManifestRecord, now: datetime, summary: RenderRunSummary) -> None:
+        """Persist an unconfirmed cache-validation fallback and schedule a retry."""
+        retry_count, retry_after = self._next_retry(record, now, summary)
+        updated = record.model_copy(
+            update={
+                "validation_status": "unconfirmed",
+                "last_attempt_at": now,
+                "retry_count": retry_count,
+                "retry_after": retry_after,
+            },
+        )
+        self.manifest_store.save(updated)
+
+    def _finalize_coverage(self, summary: RenderRunSummary) -> None:
+        """Compute the run's coverage ratio from the manifest's current state."""
+        summary.eligible_total = self.manifest_store.count_by_site(self.site_name, scope_status="eligible")
+        summary.current_total = self.manifest_store.count_by_site(
+            self.site_name,
+            scope_status="eligible",
+            fetch_status="success",
+        )
+
+    def _run_config(self, *, cache_mode: CacheMode, apply_content_cleanup: bool = True) -> CrawlerRunConfig:
         """Build the versioned Crawl4AI configuration from our stable schema."""
         markdown_generator = DefaultMarkdownGenerator(
             content_filter=PruningContentFilter(),
@@ -96,6 +443,7 @@ class Crawl4AICrawler:
             cache_mode=cache_mode,
             check_cache_freshness=cache_mode is CacheMode.ENABLED,
             page_timeout=self.config.page_timeout * 1_000,
+            word_count_threshold=self.config.word_count_threshold,
             excluded_tags=EXCLUDED_TAGS,
             # Crawl4AI accepts ``None`` for both options despite declaring the
             # parameters as non-optional. Preserve its documented defaults.
@@ -110,123 +458,30 @@ class Crawl4AICrawler:
                 )
             ),
             markdown_generator=markdown_generator,
-            deep_crawl_strategy=(
-                BFSDeepCrawlStrategy(
-                    max_depth=self.config.max_depth,
-                    max_pages=self.config.max_pages,
-                    include_external=False,
-                )
-                if deep_crawl
-                else None
-            ),
             remove_consent_popups=(self.config.remove_consent_popups if apply_content_cleanup else False),
             remove_overlay_elements=(self.config.remove_overlay_elements if apply_content_cleanup else False),
-            # BFSDeepCrawlStrategy uses these when it calls arun_many for each level.
-            mean_delay=self.config.min_delay,
-            max_range=self.config.max_delay - self.config.min_delay,
-            semaphore_count=self.config.max_concurrent,
             verbose=False,
         )
 
-    @staticmethod
-    def _browser_config() -> BrowserConfig:
-        """Configure Crawl4AI to launch the installed stable Google Chrome."""
+    def _browser_config(self) -> BrowserConfig:
+        """Configure Crawl4AI to launch the installed stable Google Chrome.
+
+        Identifies the crawler with its configured ``User-Agent`` instead of
+        Crawl4AI's default browser-spoofing string, per Design Principle 7.
+        """
         return BrowserConfig(
             browser_type="chromium",
             chrome_channel="chrome",
             headless=True,
+            user_agent=self.config.politeness.user_agent,
             verbose=False,
         )
 
-    async def crawl(self, *, force: bool = False) -> list[CrawlResult]:
-        """Run the Crawl4AI job and save each useful result as Markdown."""
-        self.summary = self._empty_summary()
-        if not force and not self._is_due():
-            self.summary["skipped"] = True
-            logger.info(
-                "Skipping %s; its %s-hour re-crawl interval has not elapsed",
-                self.site_name,
-                self.config.recrawl_interval_hours,
-            )
-            return []
-
-        browser_config = self._browser_config()
-        try:
-            async with AsyncWebCrawler(config=browser_config) as crawler:
-                raw_results = cast(
-                    "CrawlResultContainer[Crawl4AIResult]",
-                    await crawler.arun(
-                        str(self.site_config.base_url),
-                        config=self._run_config(),
-                    ),
-                )
-                self.summary["fetched"] = len(raw_results)
-                saved_results = await self._save_usable_results(crawler, raw_results)
-        except Exception:
-            logger.exception("Crawl failed for site %s", self.site_name)
-            return []
-
-        self.summary["saved"] = len(saved_results)
-        if saved_results:
-            self._write_crawl_state()
-        logger.info(
-            "Crawl summary for %s: %s",
-            self.site_name,
-            self.summary,
-        )
-        return saved_results
-
-    async def _save_usable_results(
-        self,
-        crawler: AsyncWebCrawler,
-        raw_results: CrawlResultContainer[Crawl4AIResult],
-    ) -> list[CrawlResult]:
-        """Persist useful results and retry cleanup-induced near-empty results once."""
-        saved_results: list[CrawlResult] = []
-        for raw_result in raw_results:
-            self._record_status(raw_result)
-            if not raw_result.success:
-                self.summary["failed"] += 1
-                logger.warning(
-                    "Skipping failed crawl for %s: %s",
-                    raw_result.url,
-                    raw_result.error_message,
-                )
-                continue
-
-            markdown = self._markdown(raw_result)
-            if len(markdown.strip()) < self.config.minimum_content_length:
-                self.summary["near_empty"] += 1
-                self.summary["fallback_retries"] += 1
-                logger.warning(
-                    "Retrying near-empty Crawl4AI result for %s without cleanup",
-                    raw_result.url,
-                )
-                fallback_result = await self._fallback_result(crawler, raw_result.url)
-                markdown = self._markdown(fallback_result)
-                if not fallback_result.success or (len(markdown.strip()) < self.config.minimum_content_length):
-                    logger.warning(
-                        "Skipping unrecoverable near-empty result for %s",
-                        raw_result.url,
-                    )
-                    continue
-                self.summary["fallback_recoveries"] += 1
-                saved_results.append(self._save_result(fallback_result, markdown))
-                continue
-
-            saved_results.append(self._save_result(raw_result, markdown))
-        return saved_results
-
-    async def _fallback_result(
-        self,
-        crawler: AsyncWebCrawler,
-        url: str,
-    ) -> Crawl4AIResult:
+    async def _fallback_result(self, crawler: AsyncWebCrawler, url: str) -> Crawl4AIResult:
         """Retry one page without DOM cleanup or brittle selector overrides."""
         fallback_results = await crawler.arun(
             url,
             config=self._run_config(
-                deep_crawl=False,
                 apply_content_cleanup=False,
                 # The current cache entry produced unusable Markdown. Re-fetch the
                 # page once and replace that entry rather than retrying the same hit.
@@ -235,58 +490,51 @@ class Crawl4AICrawler:
         )
         return next(iter(fallback_results))
 
-    def _record_status(self, raw_result: Crawl4AIResult) -> None:
-        """Record HTTP and cache statuses from the primary bounded crawl."""
+    def _language(self) -> str | None:
+        """Return the site's single configured language, or ``None`` if ambiguous.
+
+        No real language detection exists in this codebase or in Crawl4AI's
+        metadata; using the configured scope is an honest simplification, not
+        a stub - real detection is out of scope (semantic classification is a
+        later, separately evaluated phase per the spec's non-goals).
+        """
+        languages = self.config.scope.languages
+        return languages[0] if len(languages) == 1 else None
+
+    def _record_status(self, raw_result: Crawl4AIResult, summary: RenderRunSummary) -> None:
+        """Record HTTP and cache statuses from one render."""
         status_code = getattr(raw_result, "status_code", None)
         if status_code is not None:
             status = str(status_code)
-            self.summary["status_codes"][status] = self.summary["status_codes"].get(status, 0) + 1
+            summary.status_codes[status] = summary.status_codes.get(status, 0) + 1
         cache_status = getattr(raw_result, "cache_status", None)
         if cache_status:
-            self.summary["cache_statuses"][cache_status] = self.summary["cache_statuses"].get(cache_status, 0) + 1
+            summary.cache_statuses[cache_status] = summary.cache_statuses.get(cache_status, 0) + 1
 
-    def _is_due(self) -> bool:
-        """Return whether this site has passed its successful-crawl interval."""
-        try:
-            state = json.loads(self.state_path.read_text(encoding="utf-8"))
-            last_crawl = datetime.fromisoformat(state["last_successful_crawl_at"])
-        except (
-            FileNotFoundError,
-            KeyError,
-            TypeError,
-            ValueError,
-        ):
-            return True
+    def _write_document(self, record: ManifestRecord, markdown: str) -> Path:
+        """Write a rendered page to its canonical-keyed Markdown output path.
 
-        if last_crawl.tzinfo is None:
-            last_crawl = last_crawl.replace(tzinfo=UTC)
-        return datetime.now(UTC) >= last_crawl + timedelta(
-            hours=self.config.recrawl_interval_hours,
+        Args:
+            record: The manifest record, already updated with this render's
+                metadata.
+            markdown: Non-empty Markdown content selected for persistence.
+
+        Returns:
+            The path the document was written to.
+        """
+        output_file = self.output_dir / self._filename(record.canonical_url)
+        document = frontmatter.Post(
+            markdown,
+            title=record.title,
+            source_url=record.source_url,
+            canonical_url=record.canonical_url,
+            content_hash=record.content_hash,
+            language=record.language,
+            extractor_version=record.extractor_version,
+            crawl_timestamp=(record.last_rendered_at or datetime.now(UTC)).isoformat(),
         )
-
-    def _write_crawl_state(self) -> None:
-        """Atomically record a successful crawl for site-level scheduling."""
-        state = {
-            "last_successful_crawl_at": datetime.now(UTC).isoformat(),
-            "recrawl_interval_hours": self.config.recrawl_interval_hours,
-        }
-        temporary_path = self.state_path.with_suffix(".tmp")
-        temporary_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
-        temporary_path.replace(self.state_path)
-
-    @staticmethod
-    def _empty_summary() -> CrawlSummary:
-        return {
-            "fetched": 0,
-            "saved": 0,
-            "failed": 0,
-            "near_empty": 0,
-            "fallback_retries": 0,
-            "fallback_recoveries": 0,
-            "status_codes": {},
-            "cache_statuses": {},
-            "skipped": False,
-        }
+        output_file.write_text(frontmatter.dumps(document), encoding="utf-8")
+        return output_file
 
     @staticmethod
     def _markdown(raw_result: Crawl4AIResult) -> str:
@@ -304,48 +552,16 @@ class Crawl4AICrawler:
             return str(raw_markdown)
         return ""
 
-    def _save_result(self, raw_result: Crawl4AIResult, markdown: str) -> CrawlResult:
-        """Write a crawled page to its deterministic Markdown output path.
-
-        Args:
-            raw_result: Crawl4AI result supplying source metadata.
-            markdown: Non-empty Markdown content selected for persistence.
-
-        Returns:
-            Metadata describing the saved Markdown document.
-        """
-        metadata = raw_result.metadata or {}
-        source_url = str(metadata.get("url") or raw_result.url)
-        title = str(metadata.get("title") or "Untitled document")
-        crawl_timestamp = datetime.now(UTC).isoformat()
-        output_file = self.output_dir / self._filename(source_url)
-        document = frontmatter.Post(
-            markdown,
-            title=title,
-            source_url=source_url,
-            crawl_timestamp=crawl_timestamp,
-        )
-        output_file.write_text(frontmatter.dumps(document), encoding="utf-8")
-        return CrawlResult(
-            source_url=source_url,
-            output_file=str(output_file),
-            title=title,
-            markdown_length=len(markdown),
-            depth=int(metadata.get("depth", 0)),
-            crawl_timestamp=crawl_timestamp,
-            status_code=getattr(raw_result, "status_code", None),
-        )
-
     @staticmethod
-    def _filename(source_url: str) -> str:
-        """Create a deterministic, filesystem-safe Markdown filename from a URL."""
-        parsed = urlparse(source_url)
+    def _filename(canonical_url: str) -> str:
+        """Create a deterministic, filesystem-safe Markdown filename from a canonical URL."""
+        parsed = urlparse(canonical_url)
         path = parsed.path.strip("/") or "index"
         stem = re.sub(r"[^A-Za-z0-9._-]+", "-", path).strip("-.") or "index"
         if parsed.query:
             query = re.sub(r"[^A-Za-z0-9._-]+", "-", parsed.query).strip("-.")
             stem = f"{stem}-{query}" if query else stem
-        digest = hashlib.sha256(source_url.encode("utf-8")).hexdigest()[:12]
+        digest = hashlib.sha256(canonical_url.encode("utf-8")).hexdigest()[:12]
         max_stem_length = 255 - len(".md") - len(digest) - 1
         stem = stem[:max_stem_length].rstrip("-.") or "document"
         return f"{stem}-{digest}.md"

--- a/crawler/tapio_crawler/crawler/policy.py
+++ b/crawler/tapio_crawler/crawler/policy.py
@@ -71,6 +71,13 @@ def decide_render(  # noqa: PLR0911
     if record.retry_after is not None and record.retry_after > now:
         return None
 
+    # A record that has exhausted its retry cap without ever rendering
+    # successfully has retry_after=None (backoff no longer applies), but
+    # must stay parked rather than falling into "initial_backfill" below
+    # and being retried indefinitely every run.
+    if record.retry_count > MAX_RETRY_COUNT and record.last_rendered_at is None:
+        return None
+
     if record.last_rendered_at is None:
         return RenderDecision(CacheMode.WRITE_ONLY, "initial_backfill")
 

--- a/crawler/tapio_crawler/crawler/policy.py
+++ b/crawler/tapio_crawler/crawler/policy.py
@@ -1,0 +1,100 @@
+"""Per-document render scheduling and cache-mode selection.
+
+Pure decision logic with no I/O, implementing
+docs/specs/crawler-improvements.md's Requirement 5 (per-document cache and
+refresh policy): whether a manifest record is due for rendering this run,
+and which Crawl4AI ``CacheMode`` to use if so.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from crawl4ai import CacheMode
+
+from tapio_crawler.manifest.models import ManifestRecord
+
+# Bumped whenever the extraction/metadata schema changes materially, so a
+# record rendered under an older version is treated as due for a refresh.
+EXTRACTOR_VERSION = "2"
+
+# A per-URL retry cap (Requirement 1) is not a configured value - the spec
+# does not ask for that as a tunable, so it is a fixed module constant.
+MAX_RETRY_COUNT = 5
+_BASE_BACKOFF_SECONDS = 3600
+_MAX_BACKOFF_SECONDS = 86400
+
+
+@dataclass
+class RenderDecision:
+    """Whether one manifest record is due for rendering, and how.
+
+    Attributes:
+        cache_mode: The Crawl4AI cache mode to render this URL with.
+        reason: Machine-readable reason code, for logging/summary detail.
+    """
+
+    cache_mode: CacheMode
+    reason: str
+
+
+def decide_render(  # noqa: PLR0911
+    record: ManifestRecord,
+    *,
+    trust_lastmod: bool,
+    unchanged_audit_days: int,
+    now: datetime,
+    force: bool = False,
+) -> RenderDecision | None:
+    """Decide whether ``record`` is due for rendering this run, and how.
+
+    One return per due-reason keeps each branch's condition and outcome
+    next to each other; splitting it up would trade that clarity for a
+    lower branch count.
+
+    Args:
+        record: The manifest record to evaluate.
+        trust_lastmod: The source's ``discovery.trust_lastmod`` setting -
+            whether ``sitemap_lastmod`` may trigger a re-render.
+        unchanged_audit_days: The source's ``refresh.unchanged_audit_days``.
+        now: The current time (timezone-aware ``datetime``).
+        force: When ``True``, ignore the schedule entirely and render.
+
+    Returns:
+        A ``RenderDecision`` when the record is due, or ``None`` when it
+        should be skipped this run.
+    """
+    if force:
+        return RenderDecision(CacheMode.WRITE_ONLY, "forced")
+
+    if record.retry_after is not None and record.retry_after > now:
+        return None
+
+    if record.last_rendered_at is None:
+        return RenderDecision(CacheMode.WRITE_ONLY, "initial_backfill")
+
+    if trust_lastmod and record.sitemap_lastmod and record.sitemap_lastmod > record.last_rendered_at:
+        return RenderDecision(CacheMode.WRITE_ONLY, "lastmod_changed")
+
+    if record.extractor_version != EXTRACTOR_VERSION:
+        return RenderDecision(CacheMode.ENABLED, "extractor_version_stale")
+
+    audit_anchor = record.last_attempt_at or record.last_rendered_at
+    if now >= audit_anchor + timedelta(days=unchanged_audit_days):
+        return RenderDecision(CacheMode.ENABLED, "scheduled_audit")
+
+    return None
+
+
+def retry_backoff_seconds(retry_count: int) -> float:
+    """Return the exponential backoff, in seconds, for a URL's next retry.
+
+    Args:
+        retry_count: The number of consecutive failed/unconfirmed attempts,
+            including the one that just happened.
+
+    Returns:
+        The backoff duration, capped at ``_MAX_BACKOFF_SECONDS``.
+    """
+    return min(_BASE_BACKOFF_SECONDS * (2**retry_count), _MAX_BACKOFF_SECONDS)

--- a/crawler/tapio_crawler/crawler/runner.py
+++ b/crawler/tapio_crawler/crawler/runner.py
@@ -1,46 +1,58 @@
-"""Runner that wires a site configuration into the Crawl4AI crawler."""
+"""Runner that wires a site configuration into the manifest-driven renderer."""
 
 import asyncio
 
 from tapio_crawler.config.config_models import SiteConfig
-from tapio_crawler.crawler.crawler import Crawl4AICrawler, CrawlResult, CrawlSummary
+from tapio_crawler.crawler.crawler import Crawl4AICrawler, RenderRunSummary
+from tapio_crawler.manifest.store import ManifestStore
 
 
 class CrawlerRunner:
-    """Run one configured Crawl4AI collection job."""
+    """Run one manifest-driven render job for a site."""
 
-    def __init__(self) -> None:
-        """Initialize the runner with no prior run summary."""
-        self.last_summary: CrawlSummary | None = None
+    def __init__(self, manifest_store: ManifestStore) -> None:
+        """Initialize the runner with the manifest store it renders from.
+
+        Args:
+            manifest_store: Store holding discovered URL inventories.
+        """
+        self._manifest_store = manifest_store
 
     async def run_async(
         self,
         site_name: str,
         site_config: SiteConfig,
         *,
+        max_urls: int,
+        batch_size: int,
         force: bool = False,
-    ) -> list[CrawlResult]:
-        """Crawl one site asynchronously and retain its execution summary.
+    ) -> RenderRunSummary:
+        """Render one site's due manifest records asynchronously.
 
         Args:
             site_name: Identifier for the configured site.
             site_config: Collection settings for that site.
-            force: Whether to bypass the configured re-crawl interval.
+            max_urls: Hard cap on the number of records rendered this run.
+            batch_size: Manifest page size used while selecting due records.
+            force: Ignore each record's refresh schedule and render every
+                eligible record.
 
         Returns:
-            Metadata for the Markdown documents written during this run.
+            A summary of counts and completeness for this run.
         """
-        crawler = Crawl4AICrawler(site_name, site_config)
-        results = await crawler.crawl(force=force)
-        self.last_summary = crawler.summary
-        return results
+        crawler = Crawl4AICrawler(site_name, site_config, self._manifest_store)
+        return await crawler.crawl(max_urls=max_urls, batch_size=batch_size, force=force)
 
     def run(
         self,
         site_name: str,
         site_config: SiteConfig,
         *,
+        max_urls: int,
+        batch_size: int,
         force: bool = False,
-    ) -> list[CrawlResult]:
+    ) -> RenderRunSummary:
         """Synchronous convenience wrapper for the Typer command."""
-        return asyncio.run(self.run_async(site_name, site_config, force=force))
+        return asyncio.run(
+            self.run_async(site_name, site_config, max_urls=max_urls, batch_size=batch_size, force=force),
+        )

--- a/crawler/tapio_crawler/discovery/rate_limiter.py
+++ b/crawler/tapio_crawler/discovery/rate_limiter.py
@@ -94,7 +94,7 @@ class HostRateLimiter:
         whether the requested suspension exceeded the cap and pending URLs
         for this host should be marked ``incomplete`` for this run.
         """
-        seconds = _parse_retry_after(retry_after_value)
+        seconds = parse_retry_after(retry_after_value)
         if seconds is None:
             seconds = self.max_delay
             self.last_suspension_capped = False
@@ -108,7 +108,7 @@ class HostRateLimiter:
         return seconds
 
 
-def _parse_retry_after(value: str | None) -> float | None:
+def parse_retry_after(value: str | None) -> float | None:
     """Parse Retry-After as delay-seconds or an HTTP-date, per RFC 9110."""
     if not value:
         return None

--- a/crawler/tapio_crawler/manifest/models.py
+++ b/crawler/tapio_crawler/manifest/models.py
@@ -43,6 +43,8 @@ class ManifestRecord(BaseModel):
         fetch_status: Outcome of the most recent fetch attempt, if any.
         last_attempt_at: Timestamp of the most recent fetch attempt.
         retry_after: Earliest time a failed fetch should be retried.
+        retry_count: Consecutive failed/unconfirmed attempts since the last
+            success; resets to 0 on a successful render.
         content_hash: Hash of the fetched content, used to detect changes.
         content_length: Byte length of the fetched content.
         title: Page title extracted from the fetched content.
@@ -68,6 +70,7 @@ class ManifestRecord(BaseModel):
     fetch_status: str | None = None
     last_attempt_at: datetime | None = None
     retry_after: datetime | None = None
+    retry_count: int = 0
     content_hash: str | None = None
     content_length: int | None = None
     title: str | None = None

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -69,7 +69,27 @@ class ManifestStore:
         self._connection = sqlite3.connect(self.path)
         self._connection.row_factory = sqlite3.Row
         self._connection.execute(_SCHEMA)
+        self._add_missing_columns()
         self._connection.commit()
+
+    def _add_missing_columns(self) -> None:
+        """Add any missing column, so an older database file doesn't fail.
+
+        Compares ``_COLUMNS`` against the database's actual columns and adds
+        whatever is missing, so opening a file created by an older schema
+        version doesn't fail on the first read/write that touches a newer
+        column.
+        """
+        existing = {row["name"] for row in self._connection.execute("PRAGMA table_info(manifest)")}
+        for name in _COLUMNS:
+            if name in existing:
+                continue
+            # Column names are drawn from the fixed _COLUMNS tuple, never
+            # from user input, so this isn't a SQL-injection vector.
+            if name in _INTEGER_COLUMNS:
+                self._connection.execute(f"ALTER TABLE manifest ADD COLUMN {name} INTEGER NOT NULL DEFAULT 0")
+            else:
+                self._connection.execute(f"ALTER TABLE manifest ADD COLUMN {name} TEXT")
 
     def close(self) -> None:
         """Release the underlying SQLite connection."""
@@ -224,16 +244,37 @@ class ManifestStore:
         old row's ``first_seen_at``/``discovery_source`` into ``new_record``
         before calling this.
 
+        If a record already exists under ``new_record.canonical_url`` (two
+        different discovered URLs redirecting to the same target, or the
+        target having its own discovery history), that existing record's
+        provenance is merged in rather than being silently overwritten:
+        ``discovery_source`` is unioned and ``first_seen_at``/``last_seen_at``
+        keep their earliest/latest values. ``new_record``'s own render-outcome
+        fields (``fetch_status``, ``content_hash``, ``last_rendered_at``,
+        etc.) always win, since it reflects the render that just happened.
+
         Args:
             site_name: Name of the configured source site.
             old_canonical_url: The record's previous canonical identity.
             new_record: The record to persist under its new canonical identity.
         """
+        existing_target = self.get(site_name, new_record.canonical_url)
+        merged = (
+            new_record
+            if existing_target is None
+            else new_record.model_copy(
+                update={
+                    "discovery_source": existing_target.discovery_source | new_record.discovery_source,
+                    "first_seen_at": min(existing_target.first_seen_at, new_record.first_seen_at),
+                    "last_seen_at": max(existing_target.last_seen_at, new_record.last_seen_at),
+                },
+            )
+        )
         self._connection.execute(
             "DELETE FROM manifest WHERE site_name = ? AND canonical_url = ?",
             (site_name, old_canonical_url),
         )
-        self._write(new_record)
+        self._write(merged)
 
     def _write(self, record: ManifestRecord) -> None:
         """Upsert ``record``'s row into the ``manifest`` table.

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -28,6 +28,7 @@ _COLUMNS = (
     "fetch_status",
     "last_attempt_at",
     "retry_after",
+    "retry_count",
     "content_hash",
     "content_length",
     "title",
@@ -39,9 +40,11 @@ _COLUMNS = (
     "validation_status",
 )
 
+_INTEGER_COLUMNS = frozenset({"content_length", "retry_count"})
+
 _SCHEMA = f"""
 CREATE TABLE IF NOT EXISTS manifest (
-    {", ".join(f"{name} TEXT" if name != "content_length" else f"{name} INTEGER" for name in _COLUMNS)},
+    {", ".join(f"{name} INTEGER" if name in _INTEGER_COLUMNS else f"{name} TEXT" for name in _COLUMNS)},
     PRIMARY KEY (site_name, canonical_url)
 );
 """
@@ -141,6 +144,96 @@ class ManifestStore:
             params.append(scope_status)
         rows = self._connection.execute(query, params).fetchall()
         return [_row_to_record(row) for row in rows]
+
+    def count_by_site(
+        self,
+        site_name: str,
+        *,
+        scope_status: str | None = None,
+        fetch_status: str | None = None,
+    ) -> int:
+        """Return the number of manifest records for one site, optionally filtered.
+
+        Args:
+            site_name: Name of the configured source site.
+            scope_status: When given, only count records with this ``scope_status``.
+            fetch_status: When given, only count records with this ``fetch_status``.
+
+        Returns:
+            The matching row count.
+        """
+        query = "SELECT COUNT(*) FROM manifest WHERE site_name = ?"
+        params: list[object] = [site_name]
+        if scope_status is not None:
+            query += " AND scope_status = ?"
+            params.append(scope_status)
+        if fetch_status is not None:
+            query += " AND fetch_status = ?"
+            params.append(fetch_status)
+        row = self._connection.execute(query, params).fetchone()
+        return int(row[0])
+
+    def save(self, record: ManifestRecord) -> None:
+        """Persist ``record`` verbatim, without ``upsert()``'s discovery-merge policy.
+
+        Args:
+            record: The full record to write, already read and mutated by
+                the caller (for example, after a render attempt).
+        """
+        self._write(record)
+
+    def list_eligible_page(
+        self,
+        site_name: str,
+        *,
+        after_canonical_url: str = "",
+        limit: int = 500,
+    ) -> list[ManifestRecord]:
+        """Return one keyset-paginated page of a site's eligible records.
+
+        Args:
+            site_name: Name of the configured source site.
+            after_canonical_url: Return records whose ``canonical_url`` sorts
+                strictly after this value. Empty string starts from the
+                beginning.
+            limit: Maximum number of records to return.
+
+        Returns:
+            Up to ``limit`` eligible records, ordered by ``canonical_url``.
+        """
+        rows = self._connection.execute(
+            "SELECT * FROM manifest WHERE site_name = ? AND scope_status = 'eligible' "
+            "AND canonical_url > ? ORDER BY canonical_url LIMIT ?",
+            (site_name, after_canonical_url, limit),
+        ).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def rekey(
+        self,
+        site_name: str,
+        old_canonical_url: str,
+        new_record: ManifestRecord,
+    ) -> None:
+        """Move a record from ``old_canonical_url`` to ``new_record.canonical_url``.
+
+        Used when rendering discovers that a URL's true canonical target
+        differs from the one it was discovered under (for example, a
+        redirect resolves to a different page). Deletes the old row and
+        writes ``new_record``, so exactly one manifest record and one
+        artifact ever exist for the resolved page. Callers should carry the
+        old row's ``first_seen_at``/``discovery_source`` into ``new_record``
+        before calling this.
+
+        Args:
+            site_name: Name of the configured source site.
+            old_canonical_url: The record's previous canonical identity.
+            new_record: The record to persist under its new canonical identity.
+        """
+        self._connection.execute(
+            "DELETE FROM manifest WHERE site_name = ? AND canonical_url = ?",
+            (site_name, old_canonical_url),
+        )
+        self._write(new_record)
 
     def _write(self, record: ManifestRecord) -> None:
         """Upsert ``record``'s row into the ``manifest`` table.

--- a/crawler/tests/config/test_config_manager.py
+++ b/crawler/tests/config/test_config_manager.py
@@ -16,8 +16,6 @@ def test_config_manager_loads_crawl4ai_config(tmp_path: Path) -> None:
     base_url: https://example.com
     description: Example site
     crawler_config:
-      max_depth: 0
-      max_pages: 1
       min_delay: 0
       max_delay: 0
 """,
@@ -27,7 +25,7 @@ def test_config_manager_loads_crawl4ai_config(tmp_path: Path) -> None:
     manager = ConfigManager.from_file(str(path))
 
     assert manager.list_available_sites() == ["example"]
-    assert manager.get_site_config("example").crawler_config.max_depth == 0
+    assert manager.get_site_config("example").crawler_config.min_delay == 0
     assert manager.get_site_descriptions() == {"example": "Example site"}
 
 

--- a/crawler/tests/config/test_config_models.py
+++ b/crawler/tests/config/test_config_models.py
@@ -9,6 +9,7 @@ from tapio_crawler.config.config_models import (
     GapCrawlConfig,
     MarkdownConfig,
     PolitenessConfig,
+    RefreshConfig,
     ScopeConfig,
     SiteConfig,
     SiteConfigRegistry,
@@ -18,21 +19,24 @@ from tapio_crawler.config.config_models import (
 def test_crawler_config_has_safe_defaults() -> None:
     config = CrawlerConfig()
 
-    assert config.max_depth == 1
-    assert config.max_pages == 50
     assert config.page_timeout == 30
     assert (config.min_delay, config.max_delay) == (1.0, 3.0)
     assert config.max_concurrent == 3
+    assert config.word_count_threshold == 20
     assert config.robots_policy == "require"
     assert isinstance(config.politeness, PolitenessConfig)
     assert config.politeness.respect_crawl_delay is True
     assert "TapioBot" in config.politeness.user_agent
     assert isinstance(config.discovery, DiscoveryConfig)
     assert config.discovery.source == "none"
+    assert config.discovery.trust_lastmod is False
     assert isinstance(config.scope, ScopeConfig)
     assert config.scope.allowed_content_types == ["text/html"]
     assert isinstance(config.gap_crawl, GapCrawlConfig)
     assert config.gap_crawl.enabled is False
+    assert isinstance(config.refresh, RefreshConfig)
+    assert config.refresh.unchanged_audit_days == 90
+    assert config.refresh.coverage_target_percent == 95.0
 
 
 def test_crawler_config_rejects_invalid_delay_range() -> None:
@@ -48,7 +52,7 @@ def test_crawler_config_allows_sitemap_discovery_without_gap_crawl() -> None:
 
 @pytest.mark.parametrize(
     ("field", "value"),
-    [("max_depth", -1), ("max_pages", 0), ("max_concurrent", 0)],
+    [("max_concurrent", 0), ("word_count_threshold", -1)],
 )
 def test_crawler_config_enforces_bounds(field: str, value: int) -> None:
     with pytest.raises(ValidationError):

--- a/crawler/tests/conftest.py
+++ b/crawler/tests/conftest.py
@@ -16,8 +16,6 @@ def test_config_manager(tmp_path: Path) -> ConfigManager:
   test_site:
     base_url: https://example.com
     crawler_config:
-      max_depth: 0
-      max_pages: 1
       min_delay: 0
       max_delay: 0
 """,

--- a/crawler/tests/crawler/test_crawler.py
+++ b/crawler/tests/crawler/test_crawler.py
@@ -237,10 +237,21 @@ async def test_retry_cap_stops_scheduling_further_retries(tmp_path: Path) -> Non
     await _run(store, tmp_path, browser=browser, force=True)
 
     updated = store.get("example", "https://example.com/permit")
-    store.close()
     assert updated is not None
     assert updated.retry_count == MAX_RETRY_COUNT + 1
     assert updated.retry_after is None
+
+    # A record that exhausted its retry cap without ever rendering
+    # successfully must stay parked on a later, non-forced run rather than
+    # being immediately re-selected as an "initial backfill".
+    second_browser = mock_browser()
+    summary = await _run(store, tmp_path, browser=second_browser)
+    store.close()
+
+    second_browser.arun.assert_not_called()
+    assert summary.considered == 1
+    assert summary.skipped_not_due == 1
+    assert summary.saved == 0
 
 
 @pytest.mark.asyncio

--- a/crawler/tests/crawler/test_crawler.py
+++ b/crawler/tests/crawler/test_crawler.py
@@ -1,7 +1,6 @@
-"""Tests for the Crawl4AI-backed crawler."""
+"""Tests for the manifest-driven Crawl4AI renderer."""
 
 import hashlib
-import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,14 +10,20 @@ import frontmatter
 import pytest
 from pydantic import HttpUrl
 
-from tapio_crawler.config.config_models import CrawlerConfig, SiteConfig
-from tapio_crawler.crawler.crawler import Crawl4AICrawler
+from tapio_crawler.config.config_models import CrawlerConfig, ScopeConfig, SiteConfig
+from tapio_crawler.crawler.crawler import Crawl4AICrawler, RenderRunSummary
+from tapio_crawler.crawler.policy import EXTRACTOR_VERSION, MAX_RETRY_COUNT
+from tapio_crawler.discovery.robots import RobotsRules
+from tapio_crawler.manifest.models import ManifestRecord
+from tapio_crawler.manifest.normalize import canonicalize_url
+from tapio_crawler.manifest.store import ManifestStore
 
 
 def site_config(**overrides: object) -> SiteConfig:
+    scope = overrides.pop("scope", ScopeConfig(allowed_domains=["example.com"], languages=["en"]))
     return SiteConfig(
         base_url=HttpUrl("https://example.com"),
-        crawler_config=CrawlerConfig(max_depth=0, max_pages=1, **overrides),
+        crawler_config=CrawlerConfig(min_delay=0, max_delay=0, scope=scope, **overrides),
     )
 
 
@@ -26,215 +31,422 @@ def raw_result(
     *,
     success: bool = True,
     markdown: str = "Useful content " * 20,
-    url: str = "https://example.com/permit?id=1",
+    url: str = "https://example.com/permit",
+    status_code: int | None = 200,
+    cache_status: str = "miss",
+    response_headers: dict[str, str] | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         success=success,
         markdown=SimpleNamespace(fit_markdown=markdown),
-        metadata={"url": url, "title": "Residence permit", "depth": 0},
+        metadata={"url": url, "title": "Residence permit"},
         url=url,
-        status_code=200,
+        status_code=status_code,
+        cache_status=cache_status,
+        response_headers=response_headers or {},
         error_message="failed" if not success else None,
     )
 
 
-class CachedMarkdown:
-    """Cached Crawl4AI Markdown whose filtered field was not persisted."""
-
-    def __init__(self, content: str) -> None:
-        self.fit_markdown = ""
-        self.raw_markdown = content
-
-
-def test_run_config_uses_content_filtering_and_bounded_bfs(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler(
-        "example",
-        site_config(
-            min_delay=1,
-            max_delay=2,
-            remove_consent_popups=True,
-            remove_overlay_elements=True,
-        ),
-    )
-    config = crawler._run_config()
-
-    assert config.excluded_tags == ["nav", "header", "footer", "form"]
-    assert config.deep_crawl_strategy.max_pages == 1
-    assert config.deep_crawl_strategy.include_external is False
-    assert config.mean_delay == 1
-    assert config.max_range == 1
-    assert config.semaphore_count == 3
-    assert config.cache_mode.name == "ENABLED"
-    assert config.check_cache_freshness is True
-    assert config.remove_consent_popups is True
-    assert config.remove_overlay_elements is True
+def seed_record(store: ManifestStore, **overrides: object) -> ManifestRecord:
+    now = datetime.now(UTC)
+    defaults: dict[str, object] = {
+        "site_name": "example",
+        "source_url": "https://example.com/permit",
+        "canonical_url": "https://example.com/permit",
+        "first_seen_at": now - timedelta(days=200),
+        "last_seen_at": now,
+        "scope_status": "eligible",
+    }
+    defaults.update(overrides)
+    record = ManifestRecord(**defaults)
+    store.upsert(record)
+    return record
 
 
-def test_fallback_config_disables_brittle_cleanup() -> None:
-    crawler = Crawl4AICrawler(
-        "example",
-        site_config(
-            css_selector="#content-root",
-            remove_consent_popups=True,
-            remove_overlay_elements=True,
-        ),
-    )
-
-    config = crawler._run_config(deep_crawl=False, apply_content_cleanup=False)
-
-    assert config.deep_crawl_strategy is None
-    assert config.css_selector is None
-    assert config.target_elements == []
-    assert config.remove_consent_popups is False
-    assert config.remove_overlay_elements is False
-
-
-def test_crawl_uses_the_installed_chrome_channel() -> None:
-    crawler = Crawl4AICrawler("example", site_config())
-    browser_config = crawler._browser_config()
-
-    assert browser_config.browser_type == "chromium"
-    assert browser_config.chrome_channel == "chrome"
-
-
-def test_markdown_uses_cached_raw_markdown_when_filtered_value_is_empty() -> None:
-    raw_result_with_cached_markdown = SimpleNamespace(
-        markdown=CachedMarkdown("Cached document content"),
-    )
-
-    assert Crawl4AICrawler._markdown(raw_result_with_cached_markdown) == ("Cached document content")
-
-
-@pytest.mark.asyncio
-async def test_crawl_writes_frontmatter_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler("example", site_config())
+def mock_browser(*, arun_results: list[object] | None = None, side_effect: object = None) -> MagicMock:
     browser = MagicMock()
     browser.__aenter__ = AsyncMock(return_value=browser)
     browser.__aexit__ = AsyncMock(return_value=None)
-    browser.arun = AsyncMock(return_value=[raw_result()])
+    if side_effect is not None:
+        browser.arun = AsyncMock(side_effect=side_effect)
+    else:
+        browser.arun = AsyncMock(return_value=arun_results or [raw_result()])
+    return browser
 
-    with patch("tapio_crawler.crawler.crawler.AsyncWebCrawler", return_value=browser):
-        results = await crawler.crawl()
 
-    assert len(results) == 1
-    output = Path(results[0]["output_file"])
+async def _run(
+    store: ManifestStore,
+    content_dir: Path,
+    *,
+    config: SiteConfig | None = None,
+    browser: MagicMock | None = None,
+    max_urls: int = 5_000,
+    batch_size: int = 500,
+    force: bool = False,
+) -> RenderRunSummary:
+    with (
+        patch(
+            "tapio_crawler.crawler.crawler.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ),
+        patch(
+            "tapio_crawler.crawler.crawler.AsyncWebCrawler",
+            return_value=browser or mock_browser(),
+        ),
+        patch("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", content_dir),
+    ):
+        crawler = Crawl4AICrawler("example", config or site_config(), store)
+        return await crawler.crawl(max_urls=max_urls, batch_size=batch_size, force=force)
+
+
+@pytest.mark.asyncio
+async def test_initial_backfill_writes_frontmatter_keyed_by_canonical_url(
+    tmp_path: Path,
+) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    summary = await _run(store, tmp_path)
+    store.close()
+
+    assert summary.saved == 1
+    assert summary.complete is True
+    digest = hashlib.sha256(b"https://example.com/permit").hexdigest()[:12]
+    output = tmp_path / "example" / "parsed" / f"permit-{digest}.md"
     document = frontmatter.load(output)
-    assert document.metadata["source_url"] == "https://example.com/permit?id=1"
-    assert document.metadata["title"] == "Residence permit"
-    assert "Useful content" in document.content
-    digest = hashlib.sha256(b"https://example.com/permit?id=1").hexdigest()[:12]
-    assert output.name == f"permit-id-1-{digest}.md"
-    assert Crawl4AICrawler._filename("https://example.com/permit#one") != (
-        Crawl4AICrawler._filename("https://example.com/permit#two")
-    )
-    state = json.loads((tmp_path / "example" / "crawl_state.json").read_text())
-    assert state["recrawl_interval_hours"] == 720
+    assert document.metadata["canonical_url"] == "https://example.com/permit"
+    assert document.metadata["extractor_version"] == EXTRACTOR_VERSION
+    assert document.metadata["language"] == "en"
+    assert "content_hash" in document.metadata
 
 
 @pytest.mark.asyncio
-async def test_crawl_skips_site_within_recrawl_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler("example", site_config(recrawl_interval_hours=720))
-    crawler.state_path.write_text(
-        json.dumps(
-            {
-                "last_successful_crawl_at": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
-            },
-        ),
-        encoding="utf-8",
+async def test_resumability_skips_record_not_yet_due(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    now = datetime.now(UTC)
+    seed_record(
+        store,
+        last_rendered_at=now - timedelta(days=1),
+        last_attempt_at=now - timedelta(days=1),
+        extractor_version=EXTRACTOR_VERSION,
+        fetch_status="success",
     )
+    browser = mock_browser()
 
-    with patch("tapio_crawler.crawler.crawler.AsyncWebCrawler") as crawler_type:
-        assert await crawler.crawl() == []
+    summary = await _run(store, tmp_path, browser=browser)
+    store.close()
 
-    crawler_type.assert_not_called()
-    assert crawler.summary["skipped"] is True
+    browser.arun.assert_not_called()
+    assert summary.considered == 1
+    assert summary.skipped_not_due == 1
+    assert summary.saved == 0
+    assert summary.current_total == 1
+    assert summary.coverage_percent == 100.0
 
 
 @pytest.mark.asyncio
-async def test_force_crawl_ignores_recrawl_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler("example", site_config())
-    crawler.state_path.write_text(
-        json.dumps({"last_successful_crawl_at": datetime.now(UTC).isoformat()}),
-        encoding="utf-8",
+async def test_force_renders_a_record_that_is_not_due(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    now = datetime.now(UTC)
+    seed_record(
+        store,
+        last_rendered_at=now - timedelta(days=1),
+        last_attempt_at=now - timedelta(days=1),
+        extractor_version=EXTRACTOR_VERSION,
+        fetch_status="success",
     )
-    browser = MagicMock()
-    browser.__aenter__ = AsyncMock(return_value=browser)
-    browser.__aexit__ = AsyncMock(return_value=None)
-    browser.arun = AsyncMock(return_value=[raw_result()])
 
-    with patch("tapio_crawler.crawler.crawler.AsyncWebCrawler", return_value=browser):
-        results = await crawler.crawl(force=True)
+    summary = await _run(store, tmp_path, force=True)
 
-    assert len(results) == 1
-    assert crawler.summary["skipped"] is False
+    assert summary.saved == 1
+    store.close()
 
 
 @pytest.mark.asyncio
-async def test_crawl_rejects_failed_and_near_empty_results(
+async def test_hit_validated_confirms_without_advancing_last_rendered_at(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    now = datetime.now(UTC)
+    rendered_at = now - timedelta(days=91)
+    seed_record(
+        store,
+        last_rendered_at=rendered_at,
+        last_attempt_at=rendered_at,
+        extractor_version=EXTRACTOR_VERSION,
+        fetch_status="success",
+    )
+    browser = mock_browser(arun_results=[raw_result(cache_status="hit_validated")])
+
+    await _run(store, tmp_path, browser=browser)
+
+    updated = store.get("example", "https://example.com/permit")
+    store.close()
+    assert updated is not None
+    assert updated.validation_status == "confirmed"
+    assert updated.last_rendered_at == rendered_at
+
+
+@pytest.mark.asyncio
+async def test_hit_fallback_marks_unconfirmed_and_schedules_retry(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    now = datetime.now(UTC)
+    rendered_at = now - timedelta(days=91)
+    seed_record(
+        store,
+        last_rendered_at=rendered_at,
+        last_attempt_at=rendered_at,
+        extractor_version=EXTRACTOR_VERSION,
+        fetch_status="success",
+    )
+    browser = mock_browser(arun_results=[raw_result(cache_status="hit_fallback")])
+
+    summary = await _run(store, tmp_path, browser=browser)
+
+    updated = store.get("example", "https://example.com/permit")
+    store.close()
+    assert updated is not None
+    assert updated.validation_status == "unconfirmed"
+    assert updated.last_rendered_at == rendered_at
+    assert updated.retry_after is not None
+    assert updated.retry_after > now
+    assert summary.retried == 1
+
+
+@pytest.mark.asyncio
+async def test_render_failure_schedules_exponential_backoff(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    browser = mock_browser(arun_results=[raw_result(success=False, status_code=500)])
+
+    summary = await _run(store, tmp_path, browser=browser)
+
+    updated = store.get("example", "https://example.com/permit")
+    store.close()
+    assert updated is not None
+    assert updated.fetch_status == "failed"
+    assert updated.retry_count == 1
+    assert updated.retry_after is not None
+    assert summary.failed == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_cap_stops_scheduling_further_retries(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store, retry_count=MAX_RETRY_COUNT, fetch_status="failed")
+    browser = mock_browser(arun_results=[raw_result(success=False, status_code=500)])
+
+    await _run(store, tmp_path, browser=browser, force=True)
+
+    updated = store.get("example", "https://example.com/permit")
+    store.close()
+    assert updated is not None
+    assert updated.retry_count == MAX_RETRY_COUNT + 1
+    assert updated.retry_after is None
+
+
+@pytest.mark.asyncio
+async def test_429_extends_shared_host_suspension(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    browser = mock_browser(
+        arun_results=[
+            raw_result(success=False, status_code=429, response_headers={"Retry-After": "120"}),
+        ],
+    )
+
+    with patch("tapio_crawler.crawler.crawler.HostRateLimiter.suspend_for_retry_after") as suspend:
+        await _run(store, tmp_path, browser=browser)
+
+    store.close()
+    suspend.assert_called_once_with("120")
+
+
+@pytest.mark.asyncio
+async def test_redirect_to_different_canonical_url_rekeys_manifest_and_artifact(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler("example", site_config())
-    browser = MagicMock()
-    browser.__aenter__ = AsyncMock(return_value=browser)
-    browser.__aexit__ = AsyncMock(return_value=None)
-    browser.arun = AsyncMock(
-        return_value=[raw_result(success=False), raw_result(markdown="short")],
-    )
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store, source_url="https://example.com/old-permit", canonical_url="https://example.com/old-permit")
+    browser = mock_browser(arun_results=[raw_result(url="https://example.com/new-permit")])
 
-    with patch("tapio_crawler.crawler.crawler.AsyncWebCrawler", return_value=browser):
-        assert await crawler.crawl() == []
+    summary = await _run(store, tmp_path, browser=browser)
 
-    assert crawler.summary["failed"] == 1
-    assert crawler.summary["near_empty"] == 1
-    assert crawler.summary["fallback_retries"] == 1
-    assert crawler.summary["fallback_recoveries"] == 0
+    assert summary.saved == 1
+    old = store.get("example", "https://example.com/old-permit")
+    new = store.get("example", canonicalize_url("https://example.com/new-permit"))
+    store.close()
+    assert old is None
+    assert new is not None
+    assert new.canonical_url == "https://example.com/new-permit"
+
+    old_digest = hashlib.sha256(b"https://example.com/old-permit").hexdigest()[:12]
+    new_digest = hashlib.sha256(b"https://example.com/new-permit").hexdigest()[:12]
+    assert not (tmp_path / "example" / "parsed" / f"old-permit-{old_digest}.md").exists()
+    assert (tmp_path / "example" / "parsed" / f"new-permit-{new_digest}.md").exists()
 
 
 @pytest.mark.asyncio
-async def test_crawl_retries_cleanup_induced_near_empty_result(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler("example", site_config())
-    browser = MagicMock()
-    browser.__aenter__ = AsyncMock(return_value=browser)
-    browser.__aexit__ = AsyncMock(return_value=None)
-    browser.arun = AsyncMock(
+async def test_out_of_scope_redirect_is_discarded_not_saved(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    browser = mock_browser(arun_results=[raw_result(url="https://evil.example/permit")])
+
+    summary = await _run(store, tmp_path, browser=browser)
+
+    updated = store.get("example", "https://example.com/permit")
+    store.close()
+    assert summary.saved == 0
+    assert summary.failed == 1
+    assert updated is not None
+    assert updated.fetch_status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_near_empty_result_retries_and_recovers(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    browser = mock_browser(
         side_effect=[[raw_result(markdown="short")], [raw_result()]],
     )
 
-    with patch("tapio_crawler.crawler.crawler.AsyncWebCrawler", return_value=browser):
-        results = await crawler.crawl()
+    summary = await _run(store, tmp_path, browser=browser)
 
-    assert len(results) == 1
-    assert crawler.summary["near_empty"] == 1
-    assert crawler.summary["fallback_retries"] == 1
-    assert crawler.summary["fallback_recoveries"] == 1
-    assert crawler.summary["status_codes"] == {"200": 1}
+    store.close()
+    assert summary.low_quality == 1
+    assert summary.saved == 1
     fallback_config = browser.arun.await_args_list[1].kwargs["config"]
-    assert fallback_config.deep_crawl_strategy is None
-    assert fallback_config.remove_consent_popups is False
+    assert fallback_config.css_selector is None
     assert fallback_config.cache_mode.name == "WRITE_ONLY"
 
 
 @pytest.mark.asyncio
-async def test_crawl_handles_browser_launch_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path)
-    crawler = Crawl4AICrawler("example", site_config())
+async def test_near_empty_result_unrecoverable_marks_failure(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    browser = mock_browser(
+        side_effect=[[raw_result(markdown="short")], [raw_result(markdown="short")]],
+    )
+
+    summary = await _run(store, tmp_path, browser=browser)
+
+    store.close()
+    assert summary.low_quality == 1
+    assert summary.saved == 0
+    assert summary.failed == 1
+
+
+@pytest.mark.asyncio
+async def test_robots_required_and_unreachable_marks_run_incomplete(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+
+    with (
+        patch(
+            "tapio_crawler.crawler.crawler.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=False)),
+        ),
+        patch("tapio_crawler.crawler.crawler.DEFAULT_CONTENT_DIR", tmp_path),
+    ):
+        crawler = Crawl4AICrawler("example", site_config(), store)
+        summary = await crawler.crawl(max_urls=5_000, batch_size=500)
+
+    store.close()
+    assert summary.complete is False
+    assert summary.rendered == 0
+
+
+@pytest.mark.asyncio
+async def test_no_eligible_records_renders_nothing(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    browser = mock_browser()
+
+    summary = await _run(store, tmp_path, browser=browser)
+
+    store.close()
+    browser.arun.assert_not_called()
+    assert summary.rendered == 0
+    assert summary.saved == 0
+
+
+@pytest.mark.asyncio
+async def test_arun_exception_is_recorded_as_a_failure(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
+    browser = mock_browser(side_effect=RuntimeError("network error"))
+
+    summary = await _run(store, tmp_path, browser=browser)
+
+    updated = store.get("example", "https://example.com/permit")
+    store.close()
+    assert summary.saved == 0
+    assert updated is not None
+    assert updated.fetch_status == "failed"
+    assert updated.retry_count == 1
+
+
+@pytest.mark.asyncio
+async def test_browser_launch_failure_marks_run_incomplete(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store)
     browser = MagicMock()
     browser.__aenter__ = AsyncMock(side_effect=RuntimeError("browser unavailable"))
 
-    with patch("tapio_crawler.crawler.crawler.AsyncWebCrawler", return_value=browser):
-        assert await crawler.crawl() == []
+    summary = await _run(store, tmp_path, browser=browser)
 
-    assert crawler.summary["fetched"] == 0
+    store.close()
+    assert summary.complete is False
+    assert summary.saved == 0
+
+
+@pytest.mark.asyncio
+async def test_coverage_percent_reflects_manifest_state(tmp_path: Path) -> None:
+    store = ManifestStore(path=str(tmp_path / "manifest.db"))
+    seed_record(store, canonical_url="https://example.com/a", source_url="https://example.com/a")
+    seed_record(store, canonical_url="https://example.com/b", source_url="https://example.com/b")
+    browser = mock_browser(arun_results=[raw_result(url="https://example.com/a")])
+
+    summary = await _run(store, tmp_path, browser=browser, max_urls=1, batch_size=1)
+
+    store.close()
+    assert summary.eligible_total == 2
+    assert summary.current_total == 1
+    assert summary.coverage_percent == 50.0
+
+
+def test_coverage_percent_is_100_when_nothing_is_eligible() -> None:
+    """An empty eligible set reports full coverage rather than dividing by zero."""
+    summary = RenderRunSummary(run_id="abc", site_name="example")
+
+    assert summary.coverage_percent == 100.0
+
+
+def test_markdown_prefers_filtered_content() -> None:
+    """The filtered ``fit_markdown`` is preferred when it has content."""
+    result = SimpleNamespace(markdown=SimpleNamespace(fit_markdown="Filtered", raw_markdown="Raw"))
+
+    assert Crawl4AICrawler._markdown(result) == "Filtered"
+
+
+def test_markdown_uses_cached_raw_markdown_when_filtered_value_is_empty() -> None:
+    """An empty cached ``fit_markdown`` falls back to ``raw_markdown``."""
+    result = SimpleNamespace(markdown=SimpleNamespace(fit_markdown="", raw_markdown="Cached document content"))
+
+    assert Crawl4AICrawler._markdown(result) == "Cached document content"
+
+
+def test_markdown_returns_empty_string_when_markdown_is_none() -> None:
+    """A missing ``markdown`` field yields an empty string rather than an error."""
+    result = SimpleNamespace(markdown=None)
+
+    assert Crawl4AICrawler._markdown(result) == ""
+
+
+def test_filename_includes_normalized_query_in_stem() -> None:
+    """A canonical URL's query string becomes part of the filename stem."""
+    filename = Crawl4AICrawler._filename("https://example.com/permit?id=1")
+
+    assert filename.startswith("permit-id-1-")
+
+
+def test_filename_differs_for_different_canonical_urls() -> None:
+    """Two distinct canonical URLs never collide on the same filename."""
+    assert Crawl4AICrawler._filename("https://example.com/a") != Crawl4AICrawler._filename("https://example.com/b")

--- a/crawler/tests/crawler/test_policy.py
+++ b/crawler/tests/crawler/test_policy.py
@@ -16,6 +16,14 @@ NOW = datetime(2026, 8, 5, tzinfo=UTC)
 
 
 def _record(**overrides: object) -> ManifestRecord:
+    """Build a minimal ``ManifestRecord`` for policy tests, overriding any given fields.
+
+    Args:
+        **overrides: Field values to override on top of the defaults.
+
+    Returns:
+        The constructed record.
+    """
     defaults: dict[str, object] = {
         "site_name": "example",
         "source_url": "https://example.com/a",

--- a/crawler/tests/crawler/test_policy.py
+++ b/crawler/tests/crawler/test_policy.py
@@ -1,0 +1,145 @@
+"""Tests for per-document render scheduling and cache-mode selection."""
+
+from datetime import UTC, datetime, timedelta
+
+from crawl4ai import CacheMode
+
+from tapio_crawler.crawler.policy import (
+    EXTRACTOR_VERSION,
+    MAX_RETRY_COUNT,
+    decide_render,
+    retry_backoff_seconds,
+)
+from tapio_crawler.manifest.models import ManifestRecord
+
+NOW = datetime(2026, 8, 5, tzinfo=UTC)
+
+
+def _record(**overrides: object) -> ManifestRecord:
+    defaults: dict[str, object] = {
+        "site_name": "example",
+        "source_url": "https://example.com/a",
+        "canonical_url": "https://example.com/a",
+        "first_seen_at": NOW - timedelta(days=200),
+        "last_seen_at": NOW,
+        "scope_status": "eligible",
+    }
+    defaults.update(overrides)
+    return ManifestRecord(**defaults)
+
+
+def test_never_rendered_is_due_write_only() -> None:
+    """A record with no prior render is due for an initial backfill."""
+    record = _record()
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW)
+
+    assert decision is not None
+    assert decision.cache_mode is CacheMode.WRITE_ONLY
+    assert decision.reason == "initial_backfill"
+
+
+def test_trusted_lastmod_newer_than_render_is_due_write_only() -> None:
+    """A newer sitemap lastmod triggers a re-render only when trusted."""
+    record = _record(
+        last_rendered_at=NOW - timedelta(days=10),
+        last_attempt_at=NOW - timedelta(days=10),
+        extractor_version=EXTRACTOR_VERSION,
+        sitemap_lastmod=NOW - timedelta(days=1),
+    )
+
+    decision = decide_render(record, trust_lastmod=True, unchanged_audit_days=90, now=NOW)
+
+    assert decision is not None
+    assert decision.cache_mode is CacheMode.WRITE_ONLY
+    assert decision.reason == "lastmod_changed"
+
+
+def test_untrusted_lastmod_does_not_trigger_render() -> None:
+    """A newer lastmod is ignored when the source's trust_lastmod is False."""
+    record = _record(
+        last_rendered_at=NOW - timedelta(days=10),
+        last_attempt_at=NOW - timedelta(days=10),
+        extractor_version=EXTRACTOR_VERSION,
+        sitemap_lastmod=NOW - timedelta(days=1),
+    )
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW)
+
+    assert decision is None
+
+
+def test_stale_extractor_version_is_due_enabled() -> None:
+    """A record rendered under an older extractor version is due for refresh."""
+    record = _record(
+        last_rendered_at=NOW - timedelta(days=1),
+        last_attempt_at=NOW - timedelta(days=1),
+        extractor_version="1",
+    )
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW)
+
+    assert decision is not None
+    assert decision.cache_mode is CacheMode.ENABLED
+    assert decision.reason == "extractor_version_stale"
+
+
+def test_scheduled_audit_due_after_unchanged_audit_days() -> None:
+    """A record is due for a scheduled check once its audit window elapses."""
+    record = _record(
+        last_rendered_at=NOW - timedelta(days=91),
+        last_attempt_at=NOW - timedelta(days=91),
+        extractor_version=EXTRACTOR_VERSION,
+    )
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW)
+
+    assert decision is not None
+    assert decision.cache_mode is CacheMode.ENABLED
+    assert decision.reason == "scheduled_audit"
+
+
+def test_not_due_before_unchanged_audit_days_elapses() -> None:
+    """A recently rendered, up-to-date record is not due yet."""
+    record = _record(
+        last_rendered_at=NOW - timedelta(days=1),
+        last_attempt_at=NOW - timedelta(days=1),
+        extractor_version=EXTRACTOR_VERSION,
+    )
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW)
+
+    assert decision is None
+
+
+def test_future_retry_after_is_not_due() -> None:
+    """A record still backing off from a prior failure is skipped."""
+    record = _record(retry_after=NOW + timedelta(hours=1))
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW)
+
+    assert decision is None
+
+
+def test_force_overrides_schedule_and_backoff() -> None:
+    """``force=True`` renders even a not-yet-due or backing-off record."""
+    record = _record(
+        last_rendered_at=NOW - timedelta(days=1),
+        last_attempt_at=NOW - timedelta(days=1),
+        extractor_version=EXTRACTOR_VERSION,
+        retry_after=NOW + timedelta(hours=1),
+    )
+
+    decision = decide_render(record, trust_lastmod=False, unchanged_audit_days=90, now=NOW, force=True)
+
+    assert decision is not None
+    assert decision.cache_mode is CacheMode.WRITE_ONLY
+    assert decision.reason == "forced"
+
+
+def test_retry_backoff_grows_exponentially_and_is_capped() -> None:
+    """Backoff doubles per retry, capped at 24 hours."""
+    assert retry_backoff_seconds(1) == 3600 * 2
+    assert retry_backoff_seconds(2) == 3600 * 4
+    assert retry_backoff_seconds(MAX_RETRY_COUNT) <= 86400
+    assert retry_backoff_seconds(MAX_RETRY_COUNT + 5) == 86400

--- a/crawler/tests/crawler/test_runner.py
+++ b/crawler/tests/crawler/test_runner.py
@@ -1,33 +1,39 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import HttpUrl
 
 from tapio_crawler.config.config_models import SiteConfig
+from tapio_crawler.crawler.crawler import RenderRunSummary
 from tapio_crawler.crawler.runner import CrawlerRunner
 
 
 @pytest.mark.asyncio
 async def test_runner_wires_site_config_to_crawl4ai_crawler() -> None:
     config = SiteConfig(base_url=HttpUrl("https://example.com"))
+    manifest_store = MagicMock()
+    summary = RenderRunSummary(run_id="abc", site_name="example")
+
     with patch("tapio_crawler.crawler.runner.Crawl4AICrawler") as crawler_type:
-        crawler_type.return_value.crawl = AsyncMock(
-            return_value=[{"source_url": "https://example.com"}],
-        )
+        crawler_type.return_value.crawl = AsyncMock(return_value=summary)
 
-        runner = CrawlerRunner()
-        results = await runner.run_async("example", config)
+        runner = CrawlerRunner(manifest_store)
+        result = await runner.run_async("example", config, max_urls=5_000, batch_size=500)
 
-    crawler_type.assert_called_once_with("example", config)
-    assert results == [{"source_url": "https://example.com"}]
-    assert runner.last_summary is crawler_type.return_value.summary
+    crawler_type.assert_called_once_with("example", config, manifest_store)
+    crawler_type.return_value.crawl.assert_awaited_once_with(max_urls=5_000, batch_size=500, force=False)
+    assert result is summary
 
 
 def test_runner_runs_crawler_synchronously() -> None:
     config = SiteConfig(base_url=HttpUrl("https://example.com"))
+    manifest_store = MagicMock()
+    summary = RenderRunSummary(run_id="abc", site_name="example")
+
     with patch("tapio_crawler.crawler.runner.Crawl4AICrawler") as crawler_type:
-        crawler_type.return_value.crawl = AsyncMock(return_value=[])
+        crawler_type.return_value.crawl = AsyncMock(return_value=summary)
 
-        assert CrawlerRunner().run("example", config) == []
+        result = CrawlerRunner(manifest_store).run("example", config, max_urls=5_000, batch_size=500)
 
-    crawler_type.assert_called_once_with("example", config)
+    crawler_type.assert_called_once_with("example", config, manifest_store)
+    assert result is summary

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -1,5 +1,6 @@
 """Tests for the SQLite-backed URL manifest store."""
 
+import sqlite3
 from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -7,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from tapio_crawler.manifest.models import ManifestRecord
-from tapio_crawler.manifest.store import ManifestStore
+from tapio_crawler.manifest.store import _COLUMNS, ManifestStore
 
 
 def _record(**overrides: object) -> ManifestRecord:
@@ -179,6 +180,67 @@ def test_rekey_moves_a_record_to_a_new_canonical_identity(store: ManifestStore) 
     moved = store.get("migri", "https://migri.fi/en/new")
     assert moved is not None
     assert moved.fetch_status == "success"
+
+
+def test_rekey_merges_provenance_with_an_existing_target_record(store: ManifestStore) -> None:
+    """``rekey`` merges discovery provenance instead of overwriting an
+    already-existing record at the new canonical identity.
+    """
+    earlier = datetime(2026, 1, 1, tzinfo=UTC)
+    store.upsert(
+        _record(
+            canonical_url="https://migri.fi/en/target",
+            discovery_source={"sitemap"},
+            first_seen_at=earlier,
+            last_seen_at=earlier,
+        ),
+    )
+    store.upsert(_record(canonical_url="https://migri.fi/en/old"))
+
+    store.rekey(
+        "migri",
+        "https://migri.fi/en/old",
+        _record(
+            canonical_url="https://migri.fi/en/target",
+            discovery_source={"deep_crawl"},
+            fetch_status="success",
+        ),
+    )
+
+    assert store.get("migri", "https://migri.fi/en/old") is None
+    merged = store.get("migri", "https://migri.fi/en/target")
+    assert merged is not None
+    assert merged.discovery_source == {"sitemap", "deep_crawl"}
+    assert merged.first_seen_at == earlier
+    assert merged.fetch_status == "success"
+
+
+def test_opening_a_pre_migration_database_adds_missing_columns(tmp_path: Path) -> None:
+    """A manifest.db written before ``retry_count`` existed gains the column
+    on open, rather than every subsequent write failing with a SQLite
+    "no such column" error.
+    """
+    db_path = tmp_path / "legacy.db"
+    legacy_columns = [name for name in _COLUMNS if name != "retry_count"]
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            f"CREATE TABLE manifest ({', '.join(f'{name} TEXT' for name in legacy_columns)}, "
+            "PRIMARY KEY (site_name, canonical_url))",
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    manifest_store = ManifestStore(db_path)
+    try:
+        manifest_store.save(_record(retry_count=3))
+        found = manifest_store.get("migri", "https://migri.fi/en/page")
+    finally:
+        manifest_store.close()
+
+    assert found is not None
+    assert found.retry_count == 3
 
 
 def test_count_by_site_filters_by_scope_and_fetch_status(store: ManifestStore) -> None:

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -132,3 +132,60 @@ def test_records_from_different_sites_are_independent(store: ManifestStore) -> N
 
     assert len(store.list_by_site("migri")) == 1
     assert len(store.list_by_site("kela")) == 1
+
+
+def test_list_eligible_page_paginates_in_canonical_url_order(store: ManifestStore) -> None:
+    """Paging through eligible records with a small ``limit`` covers every
+    record exactly once, in ``canonical_url`` order.
+    """
+    for letter in "cab":
+        store.upsert(_record(canonical_url=f"https://migri.fi/en/{letter}"))
+    store.upsert(_record(canonical_url="https://migri.fi/en/d", scope_status="excluded"))
+
+    first_page = store.list_eligible_page("migri", limit=2)
+    second_page = store.list_eligible_page(
+        "migri",
+        after_canonical_url=first_page[-1].canonical_url,
+        limit=2,
+    )
+
+    assert [r.canonical_url for r in first_page] == ["https://migri.fi/en/a", "https://migri.fi/en/b"]
+    assert [r.canonical_url for r in second_page] == ["https://migri.fi/en/c"]
+
+
+def test_save_writes_a_record_verbatim_without_merge(store: ManifestStore) -> None:
+    """``save`` persists exactly the given record, unlike ``upsert``'s merge policy."""
+    store.upsert(_record(discovery_source={"sitemap"}, fetch_status=None))
+
+    store.save(_record(discovery_source=set(), fetch_status="success"))
+
+    found = store.get("migri", "https://migri.fi/en/page")
+    assert found is not None
+    assert found.discovery_source == set()
+    assert found.fetch_status == "success"
+
+
+def test_rekey_moves_a_record_to_a_new_canonical_identity(store: ManifestStore) -> None:
+    """``rekey`` deletes the old row and writes the record under its new identity."""
+    store.upsert(_record(canonical_url="https://migri.fi/en/old"))
+
+    store.rekey(
+        "migri",
+        "https://migri.fi/en/old",
+        _record(canonical_url="https://migri.fi/en/new", fetch_status="success"),
+    )
+
+    assert store.get("migri", "https://migri.fi/en/old") is None
+    moved = store.get("migri", "https://migri.fi/en/new")
+    assert moved is not None
+    assert moved.fetch_status == "success"
+
+
+def test_count_by_site_filters_by_scope_and_fetch_status(store: ManifestStore) -> None:
+    """``count_by_site`` counts only records matching the given filters."""
+    store.upsert(_record(canonical_url="https://migri.fi/en/a", fetch_status="success"))
+    store.upsert(_record(canonical_url="https://migri.fi/en/b", fetch_status="failed"))
+    store.upsert(_record(canonical_url="https://migri.fi/en/c", scope_status="excluded"))
+
+    assert store.count_by_site("migri", scope_status="eligible") == 2
+    assert store.count_by_site("migri", scope_status="eligible", fetch_status="success") == 1

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -2,11 +2,11 @@
 
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
 from typer.testing import CliRunner
 
-from tapio_crawler.cli import app, crawl
+from tapio_crawler.cli import app
 from tapio_crawler.config.config_models import SiteConfig
+from tapio_crawler.crawler.crawler import RenderRunSummary
 from tapio_crawler.discovery.runner import (
     DiscoveryRunSummary,
     MisconfiguredDiscoveryError,
@@ -22,20 +22,35 @@ def test_list_sites_displays_configured_sources() -> None:
     assert "kela" in result.stdout
 
 
-def test_crawl_raises_when_the_runner_does_not_provide_a_summary() -> None:
-    """Fail clearly when a completed crawl has no execution summary."""
+def test_crawl_reports_render_summary() -> None:
+    """The ``crawl`` command prints the render summary on success."""
     site_config = SiteConfig(base_url="https://example.com")
+    summary = RenderRunSummary(
+        run_id="abc",
+        site_name="example",
+        considered=2,
+        rendered=1,
+        saved=1,
+        eligible_total=2,
+        current_total=1,
+        complete=True,
+    )
     runner = Mock()
-    runner.run.return_value = []
-    runner.last_summary = None
+    runner.run.return_value = summary
 
     with (
         patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
+        patch("tapio_crawler.cli.ManifestStore") as manifest_store_type,
         patch("tapio_crawler.cli.CrawlerRunner", return_value=runner),
     ):
         config_manager_type.return_value.get_site_config.return_value = site_config
-        with pytest.raises(RuntimeError, match=r"^Crawler finished without a summary\.$"):
-            crawl("example", depth=None, force=False)
+        result = CliRunner().invoke(app, ["crawl", "example"])
+
+    assert result.exit_code == 0
+    assert "complete" in result.stdout
+    assert "saved 1" in result.stdout
+    assert "WARNING" in result.stdout
+    manifest_store_type.return_value.close.assert_called_once()
 
 
 def test_discover_reports_summary() -> None:

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -47,7 +47,7 @@ def test_crawl_reports_render_summary() -> None:
         result = CliRunner().invoke(app, ["crawl", "example"])
 
     assert result.exit_code == 0
-    assert "complete" in result.stdout
+    assert "for example: complete." in result.stdout
     assert "saved 1" in result.stdout
     assert "WARNING" in result.stdout
     manifest_store_type.return_value.close.assert_called_once()

--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,10 @@ fi
 failed=0
 while IFS= read -r site; do
   [ -z "$site" ] && continue
+  if ! uv run tapio-crawler discover "$site"; then
+    failed=1
+    continue
+  fi
   if ! uv run tapio-crawler crawl "$site"; then
     failed=1
   fi


### PR DESCRIPTION
## Description

Implements Phase 2 ("controlled backfill") of [docs/specs/crawler-improvements.md](docs/specs/crawler-improvements.md), building on Phase 1's manifest and discovery ([#74](https://github.com/Finntegrate/tapio/pull/74)). Covers Requirement 3 (manifest-driven collection and resumability), Requirement 4 (content selection and document quality), Requirement 5 (per-document cache and refresh policy), and the render-side counts for Requirement 6.

### Phase 1 audit

Before starting, I audited PR #74 against the spec's Phase 1 acceptance criteria: all 83 original tests, ruff, and mypy passed, and Requirements 1, 2, and the discovery-side half of Requirement 6 are correctly implemented. Two minor, non-blocking gaps were noted for a future follow-up (no `discovery.cache_ttl_hours` sitemap caching yet; robots/sitemap URLs aren't persisted as run metadata) — not fixed in this PR.

### What's included

- **Manifest-driven, resumable rendering**: `crawl <site>` no longer runs its own whole-site BFS deep crawl from `base_url` tracked by a site-wide `crawl_state.json`. It now renders only manifest records that `discover` already populated and that are due, paging through them via a new `ManifestStore.list_eligible_page`, and persists each result to the manifest immediately after it completes — so a stopped run resumes from where it left off rather than restarting.
- **Per-document cache/refresh policy** (new `crawler/policy.py`, pure and independently unit-tested): `decide_render()` implements the spec's Requirement 5 rules — initial backfill and a trusted `sitemap_lastmod` change use `CacheMode.WRITE_ONLY`; a stale extractor version or an elapsed `unchanged_audit_days` window use `CacheMode.ENABLED` with `check_cache_freshness=True`. Crawl4AI's `hit_validated`/`hit_fallback`/failure cache outcomes are each handled per their specific acceptance criteria, including exponential backoff with a per-URL retry cap, and a render-time 429/503 now extends the same shared per-host `HostRateLimiter` suspension discovery already respects.
- **Content quality and canonical-keyed artifacts**: Markdown is now keyed by `canonical_url` instead of raw `source_url` (fixing the spec-flagged bug where two URLs redirecting to the same page produced two files), with automatic rekeying via a new `ManifestStore.rekey()` when a render's redirect resolves to a different canonical URL. Frontmatter gains `canonical_url`, `content_hash`, `language`, and `extractor_version`. Also fixes a real gap the spec's Design Principle 7 called out: the render browser now sends the configured `User-Agent` instead of Crawl4AI's default Chrome-spoofing string.
- **Coverage reporting**: `crawl`'s output reports considered/rendered/saved/low-quality/failed/retried counts and a coverage ratio (current/eligible) computed from the manifest, warning when it's below the site's configured `refresh.coverage_target_percent`.
- **Config schema**: added `DiscoveryConfig.trust_lastmod`, `RefreshConfig` (`unchanged_audit_days`, `inactive_grace_cycles`, `coverage_target_percent`), and `CrawlerConfig.word_count_threshold`; removed the now-dead `max_depth`/`max_pages`/`recrawl_interval_hours` (the BFS-from-base-url path and `crawl_state.json` are gone — `GapCrawlConfig` keeps its own `max_depth`/`max_pages` for the P1 gap-crawl supplement, untouched).
- **CLI**: `crawl` drops `--depth` (no longer meaningful) and adds `--max-urls` (default 5000) and `--batch-size` (default 500) per the spec's CLI-flag contract; `--force` is re-scoped to mean "ignore each record's due-schedule."
- **Docs**: updated `crawler/README.md` and the root `README.md` for the new two-step `discover` → `crawl` workflow, and `mise.toml`'s `crawl` task now runs `discover` before `crawl` for each configured site.

### Explicitly out of scope for this PR

Gap-crawl as a *supplement* for sitemap sources (P1), retrieval evaluation (P1), operator controls — pause/cancel/concurrent site jobs (P1), all P2 items, and any change to `ingest/` (it already reads `source_url`/frontmatter independently and needs no crawler-side coupling change).

## Checklist

- [x] I ran the relevant service test suite(s) and all tests pass
- [x] I ran `uv run ruff check .` in `crawler/` and addressed any issues
- [x] I ran the package-local mypy and Pyrefly commands documented in `CONTRIBUTING.md` and addressed any issues
- [x] New/changed code meets the project's 80% coverage guideline (97% for `crawler/tapio_crawler`, `uv run pytest --cov=tapio_crawler`)
- [x] I updated `README.md` (both root and `crawler/`) since this PR changes user-facing behavior

## Related issue

Continues the "Phase 2 — controlled backfill" requirements in docs/specs/crawler-improvements.md, following on from #74. Canonical tracking issue: #72.

## Test plan

- [x] `uv run pytest --cov=tapio_crawler` — 108 passed, 97% coverage
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy tapio_crawler` and `uv run pyrefly check tapio_crawler` — clean
- [ ] Manual smoke run against the real network (`uv run tapio-crawler discover migri && uv run tapio-crawler crawl migri --max-urls 5`) if a reviewer wants end-to-end confirmation before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-step workflow: discover URLs first, then render eligible records.
  * Added resumable rendering with batching, URL limits, retries, caching, and forced refreshes.
  * Added detailed crawl summaries covering progress, failures, HTTP responses, cache status, and coverage.
  * Added canonical URL handling, redirects, robots and scope checks, quality fallbacks, and persistent document metadata.

* **Bug Fixes**
  * Improved handling of rate limits, temporary failures, retries, and failed site discovery.

* **Documentation**
  * Updated crawler usage, configuration, discovery, refresh scheduling, and failure-reporting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->