### PR TITLE
Drop language-scope filtering from crawler config

### DIFF
--- a/crawler/tapio_crawler/config/config_models.py
+++ b/crawler/tapio_crawler/config/config_models.py
@@ -43,11 +43,9 @@ class DiscoveryConfig(BaseModel):
 
 
 class ScopeConfig(BaseModel):
-    """Domain, language, and path rules bounding a source's eligible URLs."""
+    """Domain and path rules bounding a source's eligible URLs."""
 
     allowed_domains: list[str] = Field(default_factory=list)
-    languages: list[str] = Field(default_factory=list)
-    include_url_patterns: list[str] = Field(default_factory=list)
     exclude_url_patterns: list[str] = Field(default_factory=list)
     allowed_content_types: list[str] = Field(default_factory=lambda: ["text/html"])
 

--- a/crawler/tapio_crawler/config/site_configs.yaml
+++ b/crawler/tapio_crawler/config/site_configs.yaml
@@ -22,8 +22,6 @@ sites:
         sitemap_urls: []
       scope:
         allowed_domains: ["migri.fi", "www.migri.fi"]
-        languages: ["en"]
-        include_url_patterns: ["/en/*"]
         exclude_url_patterns:
           - "*/search*"
           - "*/login*"
@@ -50,8 +48,6 @@ sites:
         source: none
       scope:
         allowed_domains: ["tyomarkkinatori.fi"]
-        languages: ["en"]
-        include_url_patterns: ["/en/*"]
         exclude_url_patterns:
           - "*/search*"
           - "*/login*"
@@ -59,7 +55,7 @@ sites:
         allowed_content_types: ["text/html"]
       gap_crawl:
         enabled: true
-        seed_urls: ["https://tyomarkkinatori.fi/en"]
+        seed_urls: ["https://tyomarkkinatori.fi"]
         strategy: bfs
         max_depth: 4
         max_pages: 300
@@ -81,8 +77,6 @@ sites:
         sitemap_urls: []
       scope:
         allowed_domains: ["kela.fi", "www.kela.fi"]
-        languages: ["en"]
-        include_url_patterns: ["/en/*"]
         exclude_url_patterns:
           - "*/search*"
           - "*/login*"
@@ -91,7 +85,7 @@ sites:
 
   # Example configuration for Vero website
   vero:
-    base_url: "https://www.vero.fi/en/"
+    base_url: "https://www.vero.fi/"
     description: "Vero (Guidance about taxation in Finland) website"
     crawler_config:
       min_delay: 1.0
@@ -107,8 +101,6 @@ sites:
         sitemap_urls: []
       scope:
         allowed_domains: ["vero.fi", "www.vero.fi"]
-        languages: ["en"]
-        include_url_patterns: ["/en/*"]
         exclude_url_patterns:
           - "*/search*"
           - "*/login*"
@@ -134,8 +126,6 @@ sites:
         sitemap_urls: []
       scope:
         allowed_domains: ["dvv.fi", "www.dvv.fi"]
-        languages: ["en"]
-        include_url_patterns: ["/en/*"]
         exclude_url_patterns:
           - "*/search*"
           - "*/login*"

--- a/crawler/tapio_crawler/crawler/crawler.py
+++ b/crawler/tapio_crawler/crawler/crawler.py
@@ -324,7 +324,6 @@ class Crawl4AICrawler:
             "content_hash": content_hash,
             "content_length": len(markdown),
             "title": title,
-            "language": self._language(),
             "retry_count": 0,
             "retry_after": None,
         }
@@ -489,17 +488,6 @@ class Crawl4AICrawler:
             ),
         )
         return next(iter(fallback_results))
-
-    def _language(self) -> str | None:
-        """Return the site's single configured language, or ``None`` if ambiguous.
-
-        No real language detection exists in this codebase or in Crawl4AI's
-        metadata; using the configured scope is an honest simplification, not
-        a stub - real detection is out of scope (semantic classification is a
-        later, separately evaluated phase per the spec's non-goals).
-        """
-        languages = self.config.scope.languages
-        return languages[0] if len(languages) == 1 else None
 
     def _record_status(self, raw_result: Crawl4AIResult, summary: RenderRunSummary) -> None:
         """Record HTTP and cache statuses from one render."""

--- a/crawler/tapio_crawler/discovery/gap_crawl.py
+++ b/crawler/tapio_crawler/discovery/gap_crawl.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import cast
 
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
 from crawl4ai.deep_crawling import BFSDeepCrawlStrategy
@@ -17,7 +17,6 @@ from crawl4ai.deep_crawling.filters import (
     DomainFilter,
     FilterChain,
     URLFilter,
-    URLPatternFilter,
 )
 from crawl4ai.models import CrawlResultContainer
 
@@ -95,10 +94,6 @@ def _build_filters(scope: ScopeConfig) -> list[URLFilter]:
     filters: list[URLFilter] = []
     if scope.allowed_domains:
         filters.append(DomainFilter(allowed_domains=scope.allowed_domains))
-    if scope.include_url_patterns:
-        filters.append(
-            URLPatternFilter(patterns=cast("Any", scope.include_url_patterns)),
-        )
     if scope.allowed_content_types:
         filters.append(ContentTypeFilter(allowed_types=scope.allowed_content_types))
     return filters

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 _SCOPE_REASON_STATUS: dict[str, ScopeStatus] = {
     "domain_not_allowed": "out_of_scope",
-    "not_in_include_patterns": "out_of_scope",
     "excluded_by_pattern": "excluded",
 }
 

--- a/crawler/tapio_crawler/discovery/scope.py
+++ b/crawler/tapio_crawler/discovery/scope.py
@@ -1,8 +1,10 @@
 """Domain and path scope evaluation for a discovered URL.
 
-Content-type and language eligibility are evaluated at render time (not
-here): a URL's content type is only known after a fetch, and language
-scope is expressed as a path pattern (see ``ScopeConfig.include_url_patterns``).
+Content-type eligibility is evaluated at render time (not here): a URL's
+content type is only known after a fetch. Scope is otherwise functional
+only - allowed domains and explicit exclude patterns - per Design
+Principle in docs/specs/crawler-improvements.md; there is no language or
+other include-pattern filter.
 """
 
 from __future__ import annotations
@@ -47,8 +49,5 @@ def evaluate_scope(url: str, scope: ScopeConfig) -> ScopeDecision:
 
     if scope.exclude_url_patterns and any(fnmatch(target, pattern) for pattern in scope.exclude_url_patterns):
         return ScopeDecision(eligible=False, reason="excluded_by_pattern")
-
-    if scope.include_url_patterns and not any(fnmatch(target, pattern) for pattern in scope.include_url_patterns):
-        return ScopeDecision(eligible=False, reason="not_in_include_patterns")
 
     return ScopeDecision(eligible=True)

--- a/crawler/tests/crawler/test_crawler.py
+++ b/crawler/tests/crawler/test_crawler.py
@@ -20,7 +20,7 @@ from tapio_crawler.manifest.store import ManifestStore
 
 
 def site_config(**overrides: object) -> SiteConfig:
-    scope = overrides.pop("scope", ScopeConfig(allowed_domains=["example.com"], languages=["en"]))
+    scope = overrides.pop("scope", ScopeConfig(allowed_domains=["example.com"]))
     return SiteConfig(
         base_url=HttpUrl("https://example.com"),
         crawler_config=CrawlerConfig(min_delay=0, max_delay=0, scope=scope, **overrides),
@@ -116,7 +116,7 @@ async def test_initial_backfill_writes_frontmatter_keyed_by_canonical_url(
     document = frontmatter.load(output)
     assert document.metadata["canonical_url"] == "https://example.com/permit"
     assert document.metadata["extractor_version"] == EXTRACTOR_VERSION
-    assert document.metadata["language"] == "en"
+    assert document.metadata["language"] is None
     assert "content_hash" in document.metadata
 
 

--- a/crawler/tests/discovery/test_scope.py
+++ b/crawler/tests/discovery/test_scope.py
@@ -42,25 +42,6 @@ def test_rejects_url_with_tracking_query_pattern() -> None:
     assert decision.eligible is False
 
 
-def test_rejects_url_outside_include_patterns() -> None:
-    """A URL not matching any include pattern is rejected."""
-    scope = ScopeConfig(include_url_patterns=["/en/*"])
-
-    decision = evaluate_scope("https://migri.fi/fi/sivu", scope)
-
-    assert decision.eligible is False
-    assert decision.reason == "not_in_include_patterns"
-
-
-def test_accepts_url_within_include_patterns() -> None:
-    """A URL matching an include pattern is accepted."""
-    scope = ScopeConfig(include_url_patterns=["/en/*"])
-
-    decision = evaluate_scope("https://migri.fi/en/page", scope)
-
-    assert decision.eligible is True
-
-
 def test_no_configured_rules_accepts_everything() -> None:
     """With no scope rules configured, every URL is accepted."""
     decision = evaluate_scope("https://anything.example/path", ScopeConfig())


### PR DESCRIPTION
## Summary
- Removes `ScopeConfig.languages` and `include_url_patterns`, and every code path that read them: scope evaluation (`discovery/scope.py`), gap-crawl URL filtering (`discovery/gap_crawl.py`), the discovery scope-reason map (`discovery/runner.py`), and the crawler's derived-language manifest field (`crawler/crawler.py`).
- Sites are now crawled comprehensively per source, filtered only on `allowed_domains` / `exclude_url_patterns` / `allowed_content_types`.
- Drops the stale `/en` path from `tyomarkkinatori`'s `gap_crawl.seed_urls` and from `vero`'s `base_url`, matching the other sites' language-neutral config.
- `ManifestRecord.language` stays in the schema (harmless, forward-compatible with real future language detection) but is no longer derived from a forced single-language scope config, so it's always `None` for now.

Motivated by the 2026-08-05 discovery review: per-site language path structure is too inconsistent to scope-filter reliably (kela.fi has no language signal at all; dvv.fi uses `/se/` for Swedish, not the expected `/sv/`), and Finland's actual official languages are Finnish/Swedish, not English, so English-only scoping was wrong to begin with. Language-variant handling moves to the retrieval layer (#68).

Closes #83. Companion spec update: #85.

## Test plan
- [x] `uv run pytest -q` — 108 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy tapio_crawler` — no issues