### PR TITLE
Enable WAL mode and busy-timeout on the manifest SQLite store

### DIFF
--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -66,8 +66,15 @@ class ManifestStore:
         """
         self.path = Path(path) if path is not None else Path(DEFAULT_MANIFEST_PATH)
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._connection = sqlite3.connect(self.path)
+        # WAL lets one writer and multiple readers proceed concurrently
+        # instead of blocking on the default rollback journal; busy_timeout
+        # makes a writer wait out a momentary lock instead of raising
+        # "database is locked" immediately. Both matter once discovery/render
+        # runs for different sites open this same file concurrently (#79).
+        self._connection = sqlite3.connect(self.path, timeout=30.0)
         self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        self._connection.execute("PRAGMA busy_timeout=30000")
         self._connection.execute(_SCHEMA)
         self._add_missing_columns()
         self._connection.commit()

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -251,3 +251,23 @@ def test_count_by_site_filters_by_scope_and_fetch_status(store: ManifestStore) -
 
     assert store.count_by_site("migri", scope_status="eligible") == 2
     assert store.count_by_site("migri", scope_status="eligible", fetch_status="success") == 1
+
+
+def test_uses_wal_journal_mode(store: ManifestStore) -> None:
+    """The store opens with WAL journal mode, so concurrent per-site crawl
+    processes get one-writer/many-readers instead of blocking on the
+    default rollback journal (#79).
+    """
+    mode = store._connection.execute("PRAGMA journal_mode").fetchone()[0]
+
+    assert mode.lower() == "wal"
+
+
+def test_configures_a_busy_timeout(store: ManifestStore) -> None:
+    """The store raises SQLite's busy_timeout above its 5s default, so a
+    concurrent writer waits out a momentary lock instead of a per-site
+    crawl process immediately raising "database is locked" (#79).
+    """
+    timeout_ms = store._connection.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    assert timeout_ms == 30000


### PR DESCRIPTION
## Summary
- `sqlite3.connect()` defaulted to the rollback journal with only Python's 5s default busy timeout, so concurrent per-site discovery/render processes sharing one `manifest.db` risked "database is locked" errors once sources are crawled concurrently.
- Enables WAL journal mode (one writer, many concurrent readers instead of exclusive-lock blocking) and raises `busy_timeout` to 30s, so a writer waits out a momentary lock instead of failing immediately.
- Adds two regression tests asserting the store actually opens with `journal_mode=WAL` and the raised `busy_timeout`.

Chosen over migrating the manifest store to Postgres: no operating budget for a persistent managed database at this stage, and SQLite's portability (copy-to-bucket) is the same pattern already planned for the RAG database if ChromaDB needs to move to a live demo environment.

Closes #79. Companion spec update: #85.

## Test plan
- [x] `uv run pytest -q` — 112 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy tapio_crawler` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest database reliability during concurrent reads and writes.
  * Reduced database locking delays by allowing operations to wait up to 30 seconds.

* **Tests**
  * Added coverage verifying improved database journaling and busy-timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->