### PR TITLE
Log the underlying exception on sitemap fetch failure

### DIFF
--- a/crawler/tapio_crawler/discovery/sitemap.py
+++ b/crawler/tapio_crawler/discovery/sitemap.py
@@ -156,8 +156,8 @@ async def _fetch_sitemap(
     await rate_limiter.wait_for_turn()
     try:
         response = await client.get(sitemap_url, headers={"User-Agent": user_agent})
-    except httpx.HTTPError:
-        logger.warning("Failed to fetch sitemap %s", sitemap_url)
+    except httpx.HTTPError as exc:
+        logger.warning("Failed to fetch sitemap %s: %s: %s", sitemap_url, type(exc).__name__, exc)
         return None
 
     if response.status_code in (TOO_MANY_REQUESTS_STATUS, SERVICE_UNAVAILABLE_STATUS):

--- a/crawler/tests/discovery/test_sitemap.py
+++ b/crawler/tests/discovery/test_sitemap.py
@@ -104,6 +104,34 @@ async def test_marks_incomplete_when_a_sitemap_fetch_fails() -> None:
 
 
 @pytest.mark.asyncio
+async def test_logs_the_underlying_exception_on_a_connection_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A transport-level failure (not an HTTP error response) is marked
+    incomplete and its exception type and message are logged, so an operator
+    can distinguish a timeout from a connection reset or TLS error.
+    """
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        msg = "Connection refused"
+        raise httpx.ConnectError(msg)
+
+    transport = httpx.MockTransport(handler)
+    with caplog.at_level("WARNING"):
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await discover_sitemap_urls(
+                ["https://example.com/sitemap.xml"],
+                client=client,
+                rate_limiter=_limiter(),
+                user_agent=USER_AGENT,
+            )
+
+    assert result.complete is False
+    assert "ConnectError" in caplog.text
+    assert "Connection refused" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_marks_incomplete_when_sitemap_is_unparseable() -> None:
     """Non-XML sitemap content marks the result incomplete."""
 


### PR DESCRIPTION
## Summary
- `_fetch_sitemap` caught `httpx.HTTPError` and logged only "Failed to fetch sitemap %s" — no way to tell a timeout from a connection reset, TLS error, or other transport failure.
- Now logs the exception type and message alongside the URL.
- Added a test covering a transport-level failure (not an HTTP error response), asserting the exception type/message land in the log.

## Context
dvv.fi hit this path on ~8.6% of child-sitemap fetches during the 2026-08-05 discovery review (vs. migri.fi's 17 clean HTTP 404s) — both sources are WAF-sensitive, so knowing whether a failure is a timeout, reset, or block signal matters.

Closes #82

## Test plan
- [x] `uv run pytest tests/discovery/test_sitemap.py -q` — 8 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy tapio_crawler` — clean