### PR TITLE
Persist robots.txt/sitemap URLs as discovery run metadata

### DIFF
--- a/crawler/tapio_crawler/cli.py
+++ b/crawler/tapio_crawler/cli.py
@@ -96,11 +96,13 @@ def discover(site: str) -> None:
 
     excluded = ", ".join(f"{reason}={count}" for reason, count in summary.excluded_by_reason.items()) or "none"
     status = "complete" if summary.complete else "incomplete"
+    sitemap_urls = ", ".join(summary.sitemap_urls) or "none"
     typer.echo(
         f"Discovery run {summary.run_id} for {site}: {status}. "
         f"Discovered {summary.discovered}; eligible {summary.eligible}; "
         f"excluded: {excluded}; "
-        f"child sitemaps fetched {summary.child_sitemaps_fetched}.",
+        f"child sitemaps fetched {summary.child_sitemaps_fetched}. "
+        f"robots.txt: {summary.robots_txt_url or 'none'}; sitemaps: {sitemap_urls}.",
     )
 
 

--- a/crawler/tapio_crawler/discovery/robots.py
+++ b/crawler/tapio_crawler/discovery/robots.py
@@ -38,6 +38,7 @@ class RobotsRules:
     reachable: bool
     crawl_delay: float | None = None
     sitemap_urls: list[str] = field(default_factory=list)
+    url: str = ""
     _parser: RobotFileParser | None = None
 
     def can_fetch(self, user_agent: str, url: str) -> bool:
@@ -76,26 +77,26 @@ async def fetch_robots_rules(
             response = await http_client.get(robots_url, headers={"User-Agent": user_agent})
     except httpx.HTTPError, TimeoutError:
         logger.warning("Failed to fetch robots.txt from %s", robots_url)
-        return RobotsRules(reachable=False)
+        return RobotsRules(reachable=False, url=robots_url)
     finally:
         if owns_client:
             await http_client.aclose()
 
     if response.status_code == NOT_FOUND_STATUS:
-        return RobotsRules(reachable=True)
+        return RobotsRules(reachable=True, url=robots_url)
     if rate_limiter is not None and response.status_code in (
         TOO_MANY_REQUESTS_STATUS,
         SERVICE_UNAVAILABLE_STATUS,
     ):
         rate_limiter.suspend_for_retry_after(response.headers.get("Retry-After"))
-        return RobotsRules(reachable=False)
+        return RobotsRules(reachable=False, url=robots_url)
     if response.status_code >= CLIENT_ERROR_STATUS:
         logger.warning(
             "robots.txt fetch for %s returned HTTP %s",
             robots_url,
             response.status_code,
         )
-        return RobotsRules(reachable=False)
+        return RobotsRules(reachable=False, url=robots_url)
 
     parser = RobotFileParser()
     parser.parse(response.text.splitlines())
@@ -103,6 +104,7 @@ async def fetch_robots_rules(
         reachable=True,
         crawl_delay=_own_or_wildcard_crawl_delay(parser, user_agent),
         sitemap_urls=list(parser.site_maps() or []),
+        url=robots_url,
         _parser=parser,
     )
 

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -48,6 +48,9 @@ class DiscoveryRunSummary:
             source was a sitemap index.
         complete: Whether the run finished without a fatal interruption
             (for example, an unreachable robots.txt or a failed fetch).
+        robots_txt_url: The robots.txt URL this run fetched.
+        sitemap_urls: The top-level sitemap URLs this run fetched from,
+            empty for a gap-crawl-only source.
     """
 
     run_id: str
@@ -57,6 +60,8 @@ class DiscoveryRunSummary:
     excluded_by_reason: dict[str, int] = field(default_factory=dict)
     child_sitemaps_fetched: int = 0
     complete: bool = True
+    robots_txt_url: str = ""
+    sitemap_urls: list[str] = field(default_factory=list)
 
 
 class MisconfiguredDiscoveryError(Exception):
@@ -99,6 +104,7 @@ class DiscoveryRunner:
             config.politeness.user_agent,
             rate_limiter=rate_limiter,
         )
+        summary.robots_txt_url = robots.url
         if not robots.reachable and config.robots_policy == "require":
             summary.complete = False
             logger.warning("robots.txt unreachable for %s; marking run incomplete", site_name)
@@ -138,6 +144,7 @@ class DiscoveryRunner:
         """Dispatch to sitemap or gap-crawl discovery and update run counts."""
         if config.discovery.source == "sitemap":
             sitemap_urls = config.discovery.sitemap_urls or robots.sitemap_urls
+            summary.sitemap_urls = sitemap_urls
             async with httpx.AsyncClient() as client:
                 sitemap_result = await discover_sitemap_urls(
                     sitemap_urls,

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -120,6 +120,65 @@ async def test_sitemap_discovery_upserts_eligible_and_excluded_urls(
 
 
 @pytest.mark.asyncio
+async def test_summary_records_robots_and_sitemap_urls_used(
+    store: ManifestStore,
+) -> None:
+    """The run summary records the resolved robots.txt URL and the
+    top-level sitemap URLs used for discovery.
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]),
+    )
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True, url="https://example.com/robots.txt")),
+        ),
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=SitemapDiscoveryResult()),
+        ),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.robots_txt_url == "https://example.com/robots.txt"
+    assert summary.sitemap_urls == ["https://example.com/sitemap.xml"]
+
+
+@pytest.mark.asyncio
+async def test_summary_falls_back_to_robots_discovered_sitemap_urls(
+    store: ManifestStore,
+) -> None:
+    """When no sitemap URLs are configured, the summary records the ones
+    discovered from robots.txt instead.
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(discovery=DiscoveryConfig(source="sitemap"))
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(
+                return_value=RobotsRules(
+                    reachable=True,
+                    url="https://example.com/robots.txt",
+                    sitemap_urls=["https://example.com/from-robots.xml"],
+                ),
+            ),
+        ),
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=SitemapDiscoveryResult()),
+        ),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.sitemap_urls == ["https://example.com/from-robots.xml"]
+
+
+@pytest.mark.asyncio
 async def test_gap_crawl_discovery_used_when_no_sitemap(store: ManifestStore) -> None:
     """Gap-crawl discovery is used when no sitemap source is configured."""
     runner = DiscoveryRunner(store)

--- a/crawler/tests/discovery/test_robots.py
+++ b/crawler/tests/discovery/test_robots.py
@@ -136,6 +136,45 @@ async def test_disallowed_path_is_reported() -> None:
 
 
 @pytest.mark.asyncio
+async def test_records_the_fetched_robots_txt_url() -> None:
+    """The resolved robots.txt URL is recorded, on both success and failure,
+    so a discovery run can report which URL it actually used.
+    """
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.url == "https://example.com/robots.txt"
+
+
+@pytest.mark.asyncio
+async def test_records_the_attempted_robots_txt_url_on_failure() -> None:
+    """An unreachable robots.txt still records the URL that was attempted."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        rules = await fetch_robots_rules(
+            "https://example.com",
+            USER_AGENT,
+            client=client,
+        )
+
+    assert rules.reachable is False
+    assert rules.url == "https://example.com/robots.txt"
+
+
+@pytest.mark.asyncio
 async def test_extracts_sitemap_urls() -> None:
     body = "Sitemap: https://example.com/sitemap.xml\n"
 

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -64,6 +64,8 @@ def test_discover_reports_summary() -> None:
         excluded_by_reason={"domain_not_allowed": 1},
         child_sitemaps_fetched=1,
         complete=True,
+        robots_txt_url="https://example.com/robots.txt",
+        sitemap_urls=["https://example.com/sitemap.xml"],
     )
     runner = Mock()
     runner.run = AsyncMock(return_value=summary)
@@ -79,6 +81,8 @@ def test_discover_reports_summary() -> None:
     assert result.exit_code == 0
     assert "complete" in result.stdout
     assert "eligible 1" in result.stdout
+    assert "https://example.com/robots.txt" in result.stdout
+    assert "https://example.com/sitemap.xml" in result.stdout
     manifest_store_type.return_value.close.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- `DiscoveryRunner` fetched and used `robots.txt` and sitemap URLs internally but never surfaced them anywhere queryable — an operator investigating a discovery run had no record of which sitemap URLs it actually used.
- `RobotsRules` now carries the resolved `robots.txt` URL (`url` field, set on every code path including failures, so a failed fetch still records what was attempted).
- `DiscoveryRunSummary` now carries `robots_txt_url` and `sitemap_urls` (the top-level sitemap entrypoints actually used — either configured explicitly or discovered from robots.txt).
- The `discover` CLI command prints both in its run-summary line.

There's no persistent run-history table yet, so this surfaces the metadata through the existing run-summary mechanism (CLI output), consistent with how `child_sitemaps_fetched` is already reported. A queryable run-history table is a larger, separate change if needed later.

Closes #77

## Test plan
- [x] `uv run pytest -q` — 114 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy tapio_crawler` — clean