### PR TITLE
Cache sitemap discovery results via discovery.cache_ttl_hours

### DIFF
--- a/crawler/tapio_crawler/cli.py
+++ b/crawler/tapio_crawler/cli.py
@@ -96,8 +96,9 @@ def discover(site: str) -> None:
 
     excluded = ", ".join(f"{reason}={count}" for reason, count in summary.excluded_by_reason.items()) or "none"
     status = "complete" if summary.complete else "incomplete"
+    cache_note = " (cache hit; no HTTP requests made)" if summary.cached else ""
     typer.echo(
-        f"Discovery run {summary.run_id} for {site}: {status}. "
+        f"Discovery run {summary.run_id} for {site}: {status}{cache_note}. "
         f"Discovered {summary.discovered}; eligible {summary.eligible}; "
         f"excluded: {excluded}; "
         f"child sitemaps fetched {summary.child_sitemaps_fetched}.",

--- a/crawler/tapio_crawler/config/config_models.py
+++ b/crawler/tapio_crawler/config/config_models.py
@@ -40,6 +40,10 @@ class DiscoveryConfig(BaseModel):
     # False until a source's lastmod is empirically shown to correlate with
     # real content changes, per docs/specs/crawler-improvements.md.
     trust_lastmod: bool = False
+    # How long a completed sitemap discovery run stays valid before a
+    # `discover` run re-fetches, instead of reusing the manifest's existing
+    # discovery state. 0 disables caching and always re-fetches.
+    cache_ttl_hours: Annotated[float, Field(ge=0)] = 24.0
 
 
 class ScopeConfig(BaseModel):

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -40,14 +40,25 @@ _SCOPE_REASON_STATUS: dict[str, ScopeStatus] = {
 _CONFIG_FINGERPRINT_VERSION = "v1"
 
 
-def _config_fingerprint(config: CrawlerConfig) -> str:
+def _config_fingerprint(config: CrawlerConfig, base_url: str) -> str:
     """Hash the discovery/scope settings a cached run's counts depend on.
 
     Used to invalidate a ``discovery.cache_ttl_hours`` cache hit when
-    ``sitemap_urls`` or the site's scope rules change, even within the TTL
-    window that would otherwise still consider the cache fresh.
+    ``sitemap_urls``, the site's scope rules, or its base URL change, even
+    within the TTL window that would otherwise still consider the cache
+    fresh.
+
+    Args:
+        config: The site's crawler configuration.
+        base_url: The site's configured base URL, normalized (trailing
+            slash stripped) before hashing so equivalent URLs fingerprint
+            the same way.
+
+    Returns:
+        A version-prefixed hex digest, for example ``"v1:<hex>"``.
     """
     payload = {
+        "base_url": base_url.rstrip("/"),
         "discovery_source": config.discovery.source,
         "sitemap_urls": config.discovery.sitemap_urls,
         "allowed_domains": config.scope.allowed_domains,
@@ -121,15 +132,16 @@ class DiscoveryRunner:
         run_id = str(uuid.uuid4())
         summary = DiscoveryRunSummary(run_id=run_id, site_name=site_name)
         config = site_config.crawler_config
+        base_url = str(site_config.base_url).rstrip("/")
         _require_discovery_source(site_name, config)
         is_sitemap_source = config.discovery.source == "sitemap"
 
         if is_sitemap_source and config.discovery.cache_ttl_hours > 0:
-            cached_summary = self._try_cached_summary(site_name, config, summary)
+            cached_summary = self._try_cached_summary(site_name, config, base_url, summary)
             if cached_summary is not None:
                 return cached_summary
 
-        config_fingerprint = _config_fingerprint(config)
+        config_fingerprint = _config_fingerprint(config, base_url)
         if is_sitemap_source:
             # Recorded up front so an exception below (robots, sitemap fetch,
             # or persistence) leaves the site's last recorded run marked
@@ -145,7 +157,6 @@ class DiscoveryRunner:
         # Shared across robots, sitemap, and gap-crawl requests to this host so a
         # Crawl-delay floor or Retry-After suspension applies uniformly.
         rate_limiter = HostRateLimiter(min_delay=config.min_delay, max_delay=config.max_delay)
-        base_url = str(site_config.base_url).rstrip("/")
         robots = await fetch_robots_rules(
             base_url,
             config.politeness.user_agent,
@@ -199,6 +210,7 @@ class DiscoveryRunner:
         self,
         site_name: str,
         config: CrawlerConfig,
+        base_url: str,
         summary: DiscoveryRunSummary,
     ) -> DiscoveryRunSummary | None:
         """Rebuild a summary from the manifest if the last run is still fresh.
@@ -206,6 +218,8 @@ class DiscoveryRunner:
         Args:
             site_name: Name of the configured source site.
             config: The site's crawler configuration.
+            base_url: The site's configured base URL, normalized as in
+                ``_config_fingerprint``.
             summary: The run summary to fill in on a cache hit.
 
         Returns:
@@ -215,7 +229,7 @@ class DiscoveryRunner:
         last_run = self._manifest_store.get_last_discovery_run(site_name)
         if last_run is None or not last_run.complete:
             return None
-        if last_run.config_fingerprint != _config_fingerprint(config):
+        if last_run.config_fingerprint != _config_fingerprint(config, base_url):
             return None
         age = datetime.now(UTC) - last_run.completed_at
         if age >= timedelta(hours=config.discovery.cache_ttl_hours):

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -48,6 +48,9 @@ class DiscoveryRunSummary:
             source was a sitemap index.
         complete: Whether the run finished without a fatal interruption
             (for example, an unreachable robots.txt or a failed fetch).
+        cached: Whether this summary was rebuilt from a prior discovery
+            run's manifest state, per ``discovery.cache_ttl_hours``, instead
+            of re-fetching robots.txt and the sitemap.
     """
 
     run_id: str
@@ -57,6 +60,7 @@ class DiscoveryRunSummary:
     excluded_by_reason: dict[str, int] = field(default_factory=dict)
     child_sitemaps_fetched: int = 0
     complete: bool = True
+    cached: bool = False
 
 
 class MisconfiguredDiscoveryError(Exception):
@@ -89,6 +93,12 @@ class DiscoveryRunner:
         summary = DiscoveryRunSummary(run_id=run_id, site_name=site_name)
         config = site_config.crawler_config
         _require_discovery_source(site_name, config)
+        is_sitemap_source = config.discovery.source == "sitemap"
+
+        if is_sitemap_source and config.discovery.cache_ttl_hours > 0:
+            cached_summary = self._try_cached_summary(site_name, config, summary)
+            if cached_summary is not None:
+                return cached_summary
 
         # Shared across robots, sitemap, and gap-crawl requests to this host so a
         # Crawl-delay floor or Retry-After suspension applies uniformly.
@@ -102,6 +112,8 @@ class DiscoveryRunner:
         if not robots.reachable and config.robots_policy == "require":
             summary.complete = False
             logger.warning("robots.txt unreachable for %s; marking run incomplete", site_name)
+            if is_sitemap_source:
+                self._manifest_store.record_discovery_run(site_name, datetime.now(UTC), complete=False)
             return summary
 
         effective_delay = resolve_effective_delay(
@@ -126,6 +138,44 @@ class DiscoveryRunner:
             source_tag,
             summary,
         )
+        if is_sitemap_source:
+            self._manifest_store.record_discovery_run(site_name, datetime.now(UTC), complete=summary.complete)
+        return summary
+
+    def _try_cached_summary(
+        self,
+        site_name: str,
+        config: CrawlerConfig,
+        summary: DiscoveryRunSummary,
+    ) -> DiscoveryRunSummary | None:
+        """Rebuild a summary from the manifest if the last run is still fresh.
+
+        Args:
+            site_name: Name of the configured source site.
+            config: The site's crawler configuration.
+            summary: The run summary to fill in on a cache hit.
+
+        Returns:
+            The filled-in summary on a cache hit, or ``None`` if discovery
+            should re-fetch robots.txt and the sitemap as usual.
+        """
+        last_run = self._manifest_store.get_last_discovery_run(site_name)
+        if last_run is None or not last_run.complete:
+            return None
+        age = datetime.now(UTC) - last_run.completed_at
+        if age >= timedelta(hours=config.discovery.cache_ttl_hours):
+            return None
+
+        records = self._manifest_store.list_by_site(site_name)
+        summary.discovered = len(records)
+        for record in records:
+            if record.scope_status == "eligible":
+                summary.eligible += 1
+            else:
+                reason = record.scope_reason or "unknown"
+                summary.excluded_by_reason[reason] = summary.excluded_by_reason.get(reason, 0) + 1
+        summary.complete = True
+        summary.cached = True
         return summary
 
     async def _discover_urls(

--- a/crawler/tapio_crawler/discovery/runner.py
+++ b/crawler/tapio_crawler/discovery/runner.py
@@ -6,6 +6,8 @@ resulting URL inventory in the manifest.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -32,6 +34,28 @@ _SCOPE_REASON_STATUS: dict[str, ScopeStatus] = {
     "domain_not_allowed": "out_of_scope",
     "excluded_by_pattern": "excluded",
 }
+
+# Bumped whenever the fields hashed below change, so a stored fingerprint
+# from an older version of this function never falsely matches.
+_CONFIG_FINGERPRINT_VERSION = "v1"
+
+
+def _config_fingerprint(config: CrawlerConfig) -> str:
+    """Hash the discovery/scope settings a cached run's counts depend on.
+
+    Used to invalidate a ``discovery.cache_ttl_hours`` cache hit when
+    ``sitemap_urls`` or the site's scope rules change, even within the TTL
+    window that would otherwise still consider the cache fresh.
+    """
+    payload = {
+        "discovery_source": config.discovery.source,
+        "sitemap_urls": config.discovery.sitemap_urls,
+        "allowed_domains": config.scope.allowed_domains,
+        "exclude_url_patterns": config.scope.exclude_url_patterns,
+        "allowed_content_types": config.scope.allowed_content_types,
+    }
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+    return f"{_CONFIG_FINGERPRINT_VERSION}:{digest}"
 
 
 @dataclass
@@ -105,6 +129,19 @@ class DiscoveryRunner:
             if cached_summary is not None:
                 return cached_summary
 
+        config_fingerprint = _config_fingerprint(config)
+        if is_sitemap_source:
+            # Recorded up front so an exception below (robots, sitemap fetch,
+            # or persistence) leaves the site's last recorded run marked
+            # incomplete, rather than leaving a stale prior "complete" run in
+            # place that a later call could still serve from cache.
+            self._manifest_store.record_discovery_run(
+                site_name,
+                datetime.now(UTC),
+                complete=False,
+                config_fingerprint=config_fingerprint,
+            )
+
         # Shared across robots, sitemap, and gap-crawl requests to this host so a
         # Crawl-delay floor or Retry-After suspension applies uniformly.
         rate_limiter = HostRateLimiter(min_delay=config.min_delay, max_delay=config.max_delay)
@@ -119,7 +156,12 @@ class DiscoveryRunner:
             summary.complete = False
             logger.warning("robots.txt unreachable for %s; marking run incomplete", site_name)
             if is_sitemap_source:
-                self._manifest_store.record_discovery_run(site_name, datetime.now(UTC), complete=False)
+                self._manifest_store.record_discovery_run(
+                    site_name,
+                    datetime.now(UTC),
+                    complete=False,
+                    config_fingerprint=config_fingerprint,
+                )
             return summary
 
         effective_delay = resolve_effective_delay(
@@ -145,7 +187,12 @@ class DiscoveryRunner:
             summary,
         )
         if is_sitemap_source:
-            self._manifest_store.record_discovery_run(site_name, datetime.now(UTC), complete=summary.complete)
+            self._manifest_store.record_discovery_run(
+                site_name,
+                datetime.now(UTC),
+                complete=summary.complete,
+                config_fingerprint=config_fingerprint,
+            )
         return summary
 
     def _try_cached_summary(
@@ -167,6 +214,8 @@ class DiscoveryRunner:
         """
         last_run = self._manifest_store.get_last_discovery_run(site_name)
         if last_run is None or not last_run.complete:
+            return None
+        if last_run.config_fingerprint != _config_fingerprint(config):
             return None
         age = datetime.now(UTC) - last_run.completed_at
         if age >= timedelta(hours=config.discovery.cache_ttl_hours):

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -66,6 +66,14 @@ class LastDiscoveryRun:
 
     Recorded for every discovery attempt, including incomplete ones - see
     ``get_last_discovery_run``.
+
+    Attributes:
+        completed_at: When this run finished (or was marked incomplete).
+        complete: Whether this run finished without a fatal interruption.
+        config_fingerprint: Hash of the discovery/scope config in effect for
+            this run, used to detect config changes that should invalidate
+            an otherwise-fresh cache hit. Empty for runs recorded before
+            this field was introduced.
     """
 
     completed_at: datetime

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -49,6 +50,22 @@ CREATE TABLE IF NOT EXISTS manifest (
 );
 """
 
+_DISCOVERY_RUN_SCHEMA = """
+CREATE TABLE IF NOT EXISTS discovery_run (
+    site_name TEXT PRIMARY KEY,
+    completed_at TEXT NOT NULL,
+    complete INTEGER NOT NULL
+);
+"""
+
+
+@dataclass
+class LastDiscoveryRun:
+    """When a site's discovery last completed, for a ``cache_ttl_hours`` check."""
+
+    completed_at: datetime
+    complete: bool
+
 
 class ManifestStore:
     """Durable, queryable inventory of every discovered source URL.
@@ -76,6 +93,7 @@ class ManifestStore:
         self._connection.execute("PRAGMA journal_mode=WAL")
         self._connection.execute("PRAGMA busy_timeout=30000")
         self._connection.execute(_SCHEMA)
+        self._connection.execute(_DISCOVERY_RUN_SCHEMA)
         self._add_missing_columns()
         self._connection.commit()
 
@@ -101,6 +119,47 @@ class ManifestStore:
     def close(self) -> None:
         """Release the underlying SQLite connection."""
         self._connection.close()
+
+    def record_discovery_run(self, site_name: str, completed_at: datetime, *, complete: bool) -> None:
+        """Record that a discovery run finished for ``site_name``.
+
+        Used by ``discovery.cache_ttl_hours`` to decide whether a later
+        ``discover`` run can reuse this run's manifest state instead of
+        re-fetching.
+
+        Args:
+            site_name: Name of the configured source site.
+            completed_at: When the run finished.
+            complete: Whether the run finished without a fatal interruption.
+        """
+        self._connection.execute(
+            "INSERT INTO discovery_run (site_name, completed_at, complete) VALUES (?, ?, ?) "
+            "ON CONFLICT (site_name) DO UPDATE SET completed_at = excluded.completed_at, "
+            "complete = excluded.complete",
+            (site_name, completed_at.isoformat(), int(complete)),
+        )
+        self._connection.commit()
+
+    def get_last_discovery_run(self, site_name: str) -> LastDiscoveryRun | None:
+        """Return when ``site_name``'s discovery last completed, if ever.
+
+        Args:
+            site_name: Name of the configured source site.
+
+        Returns:
+            The last recorded run, or ``None`` if discovery has never
+            completed for this site.
+        """
+        row = self._connection.execute(
+            "SELECT completed_at, complete FROM discovery_run WHERE site_name = ?",
+            (site_name,),
+        ).fetchone()
+        if row is None:
+            return None
+        return LastDiscoveryRun(
+            completed_at=datetime.fromisoformat(row["completed_at"]),
+            complete=bool(row["complete"]),
+        )
 
     def upsert(self, record: ManifestRecord) -> ManifestRecord:
         """Insert or merge ``record`` by its ``(site_name, canonical_url)`` identity.

--- a/crawler/tapio_crawler/manifest/store.py
+++ b/crawler/tapio_crawler/manifest/store.py
@@ -54,17 +54,23 @@ _DISCOVERY_RUN_SCHEMA = """
 CREATE TABLE IF NOT EXISTS discovery_run (
     site_name TEXT PRIMARY KEY,
     completed_at TEXT NOT NULL,
-    complete INTEGER NOT NULL
+    complete INTEGER NOT NULL,
+    config_fingerprint TEXT NOT NULL DEFAULT ''
 );
 """
 
 
 @dataclass
 class LastDiscoveryRun:
-    """When a site's discovery last completed, for a ``cache_ttl_hours`` check."""
+    """When a site's discovery last completed, for a ``cache_ttl_hours`` check.
+
+    Recorded for every discovery attempt, including incomplete ones - see
+    ``get_last_discovery_run``.
+    """
 
     completed_at: datetime
     complete: bool
+    config_fingerprint: str = ""
 
 
 class ManifestStore:
@@ -95,6 +101,7 @@ class ManifestStore:
         self._connection.execute(_SCHEMA)
         self._connection.execute(_DISCOVERY_RUN_SCHEMA)
         self._add_missing_columns()
+        self._add_missing_discovery_run_columns()
         self._connection.commit()
 
     def _add_missing_columns(self) -> None:
@@ -116,11 +123,24 @@ class ManifestStore:
             else:
                 self._connection.execute(f"ALTER TABLE manifest ADD COLUMN {name} TEXT")
 
+    def _add_missing_discovery_run_columns(self) -> None:
+        """Add ``config_fingerprint`` to a ``discovery_run`` table that predates it."""
+        existing = {row["name"] for row in self._connection.execute("PRAGMA table_info(discovery_run)")}
+        if "config_fingerprint" not in existing:
+            self._connection.execute("ALTER TABLE discovery_run ADD COLUMN config_fingerprint TEXT NOT NULL DEFAULT ''")
+
     def close(self) -> None:
         """Release the underlying SQLite connection."""
         self._connection.close()
 
-    def record_discovery_run(self, site_name: str, completed_at: datetime, *, complete: bool) -> None:
+    def record_discovery_run(
+        self,
+        site_name: str,
+        completed_at: datetime,
+        *,
+        complete: bool,
+        config_fingerprint: str = "",
+    ) -> None:
         """Record that a discovery run finished for ``site_name``.
 
         Used by ``discovery.cache_ttl_hours`` to decide whether a later
@@ -131,12 +151,17 @@ class ManifestStore:
             site_name: Name of the configured source site.
             completed_at: When the run finished.
             complete: Whether the run finished without a fatal interruption.
+            config_fingerprint: Hash of the discovery/scope settings this run
+                used, so a later run can tell whether the site's
+                configuration has changed since and treat a cache hit as
+                stale even within ``cache_ttl_hours``.
         """
         self._connection.execute(
-            "INSERT INTO discovery_run (site_name, completed_at, complete) VALUES (?, ?, ?) "
+            "INSERT INTO discovery_run (site_name, completed_at, complete, config_fingerprint) "
+            "VALUES (?, ?, ?, ?) "
             "ON CONFLICT (site_name) DO UPDATE SET completed_at = excluded.completed_at, "
-            "complete = excluded.complete",
-            (site_name, completed_at.isoformat(), int(complete)),
+            "complete = excluded.complete, config_fingerprint = excluded.config_fingerprint",
+            (site_name, completed_at.isoformat(), int(complete), config_fingerprint),
         )
         self._connection.commit()
 
@@ -147,11 +172,11 @@ class ManifestStore:
             site_name: Name of the configured source site.
 
         Returns:
-            The last recorded run, or ``None`` if discovery has never
-            completed for this site.
+            The most recently recorded run, including an incomplete one, or
+            ``None`` if no run has ever been recorded for this site.
         """
         row = self._connection.execute(
-            "SELECT completed_at, complete FROM discovery_run WHERE site_name = ?",
+            "SELECT completed_at, complete, config_fingerprint FROM discovery_run WHERE site_name = ?",
             (site_name,),
         ).fetchone()
         if row is None:
@@ -159,6 +184,7 @@ class ManifestStore:
         return LastDiscoveryRun(
             completed_at=datetime.fromisoformat(row["completed_at"]),
             complete=bool(row["complete"]),
+            config_fingerprint=row["config_fingerprint"] or "",
         )
 
     def upsert(self, record: ManifestRecord) -> ManifestRecord:

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -1,6 +1,7 @@
 """Tests for the discovery runner."""
 
 from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -17,6 +18,7 @@ from tapio_crawler.discovery.gap_crawl import GapCrawlResult
 from tapio_crawler.discovery.robots import RobotsRules
 from tapio_crawler.discovery.runner import DiscoveryRunner, MisconfiguredDiscoveryError
 from tapio_crawler.discovery.sitemap import SitemapDiscoveryResult, SitemapUrlEntry
+from tapio_crawler.manifest.models import ManifestRecord
 from tapio_crawler.manifest.store import ManifestStore
 
 
@@ -145,3 +147,184 @@ async def test_gap_crawl_discovery_used_when_no_sitemap(store: ManifestStore) ->
 
     assert summary.discovered == 1
     assert summary.eligible == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_http_requests_and_rebuilds_from_manifest(
+    store: ManifestStore,
+) -> None:
+    """Within ``cache_ttl_hours`` of a complete run, discover reuses the
+    manifest instead of re-fetching robots.txt or the sitemap (#76).
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            cache_ttl_hours=24,
+        ),
+    )
+    now = datetime.now(UTC)
+    store.upsert(
+        ManifestRecord(
+            site_name="example",
+            source_url="https://example.com/a",
+            canonical_url="https://example.com/a",
+            discovery_source={"sitemap"},
+            first_seen_at=now,
+            last_seen_at=now,
+            scope_status="eligible",
+        ),
+    )
+    store.upsert(
+        ManifestRecord(
+            site_name="example",
+            source_url="https://example.com/search",
+            canonical_url="https://example.com/search",
+            discovery_source={"sitemap"},
+            first_seen_at=now,
+            last_seen_at=now,
+            scope_status="excluded",
+            scope_reason="excluded_by_pattern",
+        ),
+    )
+    store.record_discovery_run("example", now, complete=True)
+
+    def _fail(*_args: object, **_kwargs: object) -> None:
+        msg = "must not make HTTP requests on a cache hit"
+        raise AssertionError(msg)
+
+    with (
+        patch("tapio_crawler.discovery.runner.fetch_robots_rules", AsyncMock(side_effect=_fail)),
+        patch("tapio_crawler.discovery.runner.discover_sitemap_urls", AsyncMock(side_effect=_fail)),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.cached is True
+    assert summary.complete is True
+    assert summary.discovered == 2
+    assert summary.eligible == 1
+    assert summary.excluded_by_reason == {"excluded_by_pattern": 1}
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_after_ttl_elapsed_refetches(store: ManifestStore) -> None:
+    """Once ``cache_ttl_hours`` has elapsed since the last complete run,
+    discover re-fetches robots.txt and the sitemap as usual (#76).
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            cache_ttl_hours=1,
+        ),
+    )
+    stale = datetime.now(UTC) - timedelta(hours=2)
+    store.record_discovery_run("example", stale, complete=True)
+
+    fake_sitemap_result = SitemapDiscoveryResult(
+        urls=[SitemapUrlEntry(url="https://example.com/a")],
+        child_sitemaps_fetched=0,
+        complete=True,
+    )
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ) as fetch_robots_mock,
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ) as discover_sitemap_mock,
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.cached is False
+    fetch_robots_mock.assert_called_once()
+    discover_sitemap_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_hours_zero_disables_caching(store: ManifestStore) -> None:
+    """``cache_ttl_hours=0`` always re-fetches, even with a very recent
+    complete run recorded (#76).
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            cache_ttl_hours=0,
+        ),
+    )
+    store.record_discovery_run("example", datetime.now(UTC), complete=True)
+
+    fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ) as fetch_robots_mock,
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ),
+    ):
+        summary = await runner.run("example", site_config)
+
+    assert summary.cached is False
+    fetch_robots_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_successful_sitemap_run_records_discovery_run(store: ManifestStore) -> None:
+    """A completed sitemap discovery run is recorded, so a later run within
+    ``cache_ttl_hours`` can be served from cache (#76).
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]),
+    )
+    fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ),
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ),
+    ):
+        await runner.run("example", site_config)
+
+    last_run = store.get_last_discovery_run("example")
+    assert last_run is not None
+    assert last_run.complete is True
+
+
+@pytest.mark.asyncio
+async def test_incomplete_run_is_recorded_as_incomplete_and_not_cached(
+    store: ManifestStore,
+) -> None:
+    """An unreachable-robots run is recorded incomplete, so a later run does
+    not serve a partial result from cache (#76).
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(source="sitemap", sitemap_urls=["https://example.com/sitemap.xml"]),
+    )
+
+    with patch(
+        "tapio_crawler.discovery.runner.fetch_robots_rules",
+        AsyncMock(return_value=RobotsRules(reachable=False)),
+    ):
+        await runner.run("example", site_config)
+
+    last_run = store.get_last_discovery_run("example")
+    assert last_run is not None
+    assert last_run.complete is False

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -255,7 +255,7 @@ async def test_cache_hit_skips_http_requests_and_rebuilds_from_manifest(
         "example",
         now,
         complete=True,
-        config_fingerprint=_config_fingerprint(site_config.crawler_config),
+        config_fingerprint=_config_fingerprint(site_config.crawler_config, str(site_config.base_url)),
     )
 
     def _fail(*_args: object, **_kwargs: object) -> None:
@@ -319,6 +319,10 @@ async def test_cache_miss_when_sitemap_urls_change_within_ttl(store: ManifestSto
     """Changing ``sitemap_urls`` invalidates a cache hit even within
     ``cache_ttl_hours``, since the cached counts were computed against a
     different sitemap (#76 follow-up).
+
+    Args:
+        store: Temporary manifest store fixture, primed with a prior run
+            recorded under the old sitemap URL's fingerprint.
     """
     runner = DiscoveryRunner(store)
     old_config = CrawlerConfig(
@@ -339,7 +343,7 @@ async def test_cache_miss_when_sitemap_urls_change_within_ttl(store: ManifestSto
         "example",
         datetime.now(UTC),
         complete=True,
-        config_fingerprint=_config_fingerprint(old_config),
+        config_fingerprint=_config_fingerprint(old_config, "https://example.com"),
     )
     fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
 
@@ -366,6 +370,10 @@ async def test_cache_miss_when_scope_config_changes_within_ttl(store: ManifestSt
     invalidates a cache hit even within ``cache_ttl_hours``, since the
     cached eligible/excluded counts were computed under the old rules (#76
     follow-up).
+
+    Args:
+        store: Temporary manifest store fixture, primed with a prior run
+            recorded under the old scope config's fingerprint.
     """
     runner = DiscoveryRunner(store)
     old_config = CrawlerConfig(
@@ -388,7 +396,51 @@ async def test_cache_miss_when_scope_config_changes_within_ttl(store: ManifestSt
         "example",
         datetime.now(UTC),
         complete=True,
-        config_fingerprint=_config_fingerprint(old_config),
+        config_fingerprint=_config_fingerprint(old_config, "https://example.com"),
+    )
+    fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ) as fetch_robots_mock,
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ) as discover_sitemap_mock,
+    ):
+        summary = await runner.run("example", new_site_config)
+
+    assert summary.cached is False
+    fetch_robots_mock.assert_called_once()
+    discover_sitemap_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_when_base_url_changes_within_ttl(store: ManifestStore) -> None:
+    """Changing a site's ``base_url`` invalidates a cache hit even within
+    ``cache_ttl_hours``, since the cached manifest records were discovered
+    from a different site origin (#76 follow-up).
+
+    Args:
+        store: Temporary manifest store fixture, primed with a prior run
+            recorded under the old base URL's fingerprint.
+    """
+    runner = DiscoveryRunner(store)
+    crawler_config = CrawlerConfig(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            cache_ttl_hours=24,
+        ),
+    )
+    new_site_config = SiteConfig(base_url="https://new.example.com", crawler_config=crawler_config)
+    store.record_discovery_run(
+        "example",
+        datetime.now(UTC),
+        complete=True,
+        config_fingerprint=_config_fingerprint(crawler_config, "https://example.com"),
     )
     fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
 
@@ -500,6 +552,11 @@ async def test_exception_during_discovery_leaves_last_run_marked_incomplete(
     """A crash while fetching the sitemap still leaves the site's last
     recorded run marked incomplete, so a later call cannot serve a cache hit
     built from a stale prior "complete" run (#76 follow-up).
+
+    Args:
+        store: Temporary manifest store fixture, primed with a prior
+            complete run so the pre-fetch incomplete marker is the only
+            thing distinguishing "before" from "after" this run.
     """
     runner = DiscoveryRunner(store)
     site_config = _site_config(
@@ -515,7 +572,7 @@ async def test_exception_during_discovery_leaves_last_run_marked_incomplete(
         "example",
         datetime.now(UTC),
         complete=True,
-        config_fingerprint=_config_fingerprint(site_config.crawler_config),
+        config_fingerprint=_config_fingerprint(site_config.crawler_config, str(site_config.base_url)),
     )
 
     with (

--- a/crawler/tests/discovery/test_discovery_runner.py
+++ b/crawler/tests/discovery/test_discovery_runner.py
@@ -16,7 +16,11 @@ from tapio_crawler.config.config_models import (
 )
 from tapio_crawler.discovery.gap_crawl import GapCrawlResult
 from tapio_crawler.discovery.robots import RobotsRules
-from tapio_crawler.discovery.runner import DiscoveryRunner, MisconfiguredDiscoveryError
+from tapio_crawler.discovery.runner import (
+    DiscoveryRunner,
+    MisconfiguredDiscoveryError,
+    _config_fingerprint,
+)
 from tapio_crawler.discovery.sitemap import SitemapDiscoveryResult, SitemapUrlEntry
 from tapio_crawler.manifest.models import ManifestRecord
 from tapio_crawler.manifest.store import ManifestStore
@@ -247,7 +251,12 @@ async def test_cache_hit_skips_http_requests_and_rebuilds_from_manifest(
             scope_reason="excluded_by_pattern",
         ),
     )
-    store.record_discovery_run("example", now, complete=True)
+    store.record_discovery_run(
+        "example",
+        now,
+        complete=True,
+        config_fingerprint=_config_fingerprint(site_config.crawler_config),
+    )
 
     def _fail(*_args: object, **_kwargs: object) -> None:
         msg = "must not make HTTP requests on a cache hit"
@@ -299,6 +308,101 @@ async def test_cache_miss_after_ttl_elapsed_refetches(store: ManifestStore) -> N
         ) as discover_sitemap_mock,
     ):
         summary = await runner.run("example", site_config)
+
+    assert summary.cached is False
+    fetch_robots_mock.assert_called_once()
+    discover_sitemap_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_when_sitemap_urls_change_within_ttl(store: ManifestStore) -> None:
+    """Changing ``sitemap_urls`` invalidates a cache hit even within
+    ``cache_ttl_hours``, since the cached counts were computed against a
+    different sitemap (#76 follow-up).
+    """
+    runner = DiscoveryRunner(store)
+    old_config = CrawlerConfig(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/old-sitemap.xml"],
+            cache_ttl_hours=24,
+        ),
+    )
+    new_site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/new-sitemap.xml"],
+            cache_ttl_hours=24,
+        ),
+    )
+    store.record_discovery_run(
+        "example",
+        datetime.now(UTC),
+        complete=True,
+        config_fingerprint=_config_fingerprint(old_config),
+    )
+    fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ) as fetch_robots_mock,
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ) as discover_sitemap_mock,
+    ):
+        summary = await runner.run("example", new_site_config)
+
+    assert summary.cached is False
+    fetch_robots_mock.assert_called_once()
+    discover_sitemap_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_when_scope_config_changes_within_ttl(store: ManifestStore) -> None:
+    """Changing scope rules (for example, a newly excluded path pattern)
+    invalidates a cache hit even within ``cache_ttl_hours``, since the
+    cached eligible/excluded counts were computed under the old rules (#76
+    follow-up).
+    """
+    runner = DiscoveryRunner(store)
+    old_config = CrawlerConfig(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            cache_ttl_hours=24,
+        ),
+        scope=ScopeConfig(exclude_url_patterns=[]),
+    )
+    new_site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            cache_ttl_hours=24,
+        ),
+        scope=ScopeConfig(exclude_url_patterns=["/search"]),
+    )
+    store.record_discovery_run(
+        "example",
+        datetime.now(UTC),
+        complete=True,
+        config_fingerprint=_config_fingerprint(old_config),
+    )
+    fake_sitemap_result = SitemapDiscoveryResult(urls=[], child_sitemaps_fetched=0, complete=True)
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ) as fetch_robots_mock,
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(return_value=fake_sitemap_result),
+        ) as discover_sitemap_mock,
+    ):
+        summary = await runner.run("example", new_site_config)
 
     assert summary.cached is False
     fetch_robots_mock.assert_called_once()
@@ -381,6 +485,49 @@ async def test_incomplete_run_is_recorded_as_incomplete_and_not_cached(
     with patch(
         "tapio_crawler.discovery.runner.fetch_robots_rules",
         AsyncMock(return_value=RobotsRules(reachable=False)),
+    ):
+        await runner.run("example", site_config)
+
+    last_run = store.get_last_discovery_run("example")
+    assert last_run is not None
+    assert last_run.complete is False
+
+
+@pytest.mark.asyncio
+async def test_exception_during_discovery_leaves_last_run_marked_incomplete(
+    store: ManifestStore,
+) -> None:
+    """A crash while fetching the sitemap still leaves the site's last
+    recorded run marked incomplete, so a later call cannot serve a cache hit
+    built from a stale prior "complete" run (#76 follow-up).
+    """
+    runner = DiscoveryRunner(store)
+    site_config = _site_config(
+        discovery=DiscoveryConfig(
+            source="sitemap",
+            sitemap_urls=["https://example.com/sitemap.xml"],
+            # Caching disabled so a prior complete run cannot short-circuit
+            # this run before it reaches the mocked failure below.
+            cache_ttl_hours=0,
+        ),
+    )
+    store.record_discovery_run(
+        "example",
+        datetime.now(UTC),
+        complete=True,
+        config_fingerprint=_config_fingerprint(site_config.crawler_config),
+    )
+
+    with (
+        patch(
+            "tapio_crawler.discovery.runner.fetch_robots_rules",
+            AsyncMock(return_value=RobotsRules(reachable=True)),
+        ),
+        patch(
+            "tapio_crawler.discovery.runner.discover_sitemap_urls",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
     ):
         await runner.run("example", site_config)
 

--- a/crawler/tests/manifest/test_store.py
+++ b/crawler/tests/manifest/test_store.py
@@ -271,3 +271,48 @@ def test_configures_a_busy_timeout(store: ManifestStore) -> None:
     timeout_ms = store._connection.execute("PRAGMA busy_timeout").fetchone()[0]
 
     assert timeout_ms == 30000
+
+
+def test_get_last_discovery_run_returns_none_when_never_recorded(
+    store: ManifestStore,
+) -> None:
+    """A site with no recorded discovery run has no cached run state (#76)."""
+    assert store.get_last_discovery_run("migri") is None
+
+
+def test_record_discovery_run_can_be_read_back(store: ManifestStore) -> None:
+    """A recorded discovery run's completion time and status round-trip (#76)."""
+    completed_at = datetime(2026, 8, 4, 12, 0, tzinfo=UTC)
+
+    store.record_discovery_run("migri", completed_at, complete=True)
+    last_run = store.get_last_discovery_run("migri")
+
+    assert last_run is not None
+    assert last_run.completed_at == completed_at
+    assert last_run.complete is True
+
+
+def test_record_discovery_run_overwrites_the_prior_run_for_a_site(
+    store: ManifestStore,
+) -> None:
+    """Recording a new discovery run replaces the site's previous run state,
+    rather than accumulating a history (#76).
+    """
+    earlier = datetime(2026, 8, 3, tzinfo=UTC)
+    later = datetime(2026, 8, 5, tzinfo=UTC)
+    store.record_discovery_run("migri", earlier, complete=False)
+
+    store.record_discovery_run("migri", later, complete=True)
+    last_run = store.get_last_discovery_run("migri")
+
+    assert last_run is not None
+    assert last_run.completed_at == later
+    assert last_run.complete is True
+
+
+def test_record_discovery_run_is_independent_per_site(store: ManifestStore) -> None:
+    """Recording a run for one site does not affect another site's state (#76)."""
+    completed_at = datetime(2026, 8, 4, tzinfo=UTC)
+    store.record_discovery_run("migri", completed_at, complete=True)
+
+    assert store.get_last_discovery_run("kela") is None

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -82,6 +82,34 @@ def test_discover_reports_summary() -> None:
     manifest_store_type.return_value.close.assert_called_once()
 
 
+def test_discover_reports_a_cache_hit() -> None:
+    """The ``discover`` command notes when the summary was served from cache."""
+    site_config = SiteConfig(base_url="https://example.com")
+    summary = DiscoveryRunSummary(
+        run_id="abc",
+        site_name="example",
+        discovered=2,
+        eligible=1,
+        excluded_by_reason={"domain_not_allowed": 1},
+        child_sitemaps_fetched=0,
+        complete=True,
+        cached=True,
+    )
+    runner = Mock()
+    runner.run = AsyncMock(return_value=summary)
+
+    with (
+        patch("tapio_crawler.cli.ConfigManager") as config_manager_type,
+        patch("tapio_crawler.cli.ManifestStore"),
+        patch("tapio_crawler.cli.DiscoveryRunner", return_value=runner),
+    ):
+        config_manager_type.return_value.get_site_config.return_value = site_config
+        result = CliRunner().invoke(app, ["discover", "example"])
+
+    assert result.exit_code == 0
+    assert "cache hit" in result.stdout
+
+
 def test_discover_exits_with_error_on_misconfiguration() -> None:
     """The ``discover`` command exits with code 1 and the error message when
     the site has no way to discover URLs.


### PR DESCRIPTION
## Summary

- Adds `discovery.cache_ttl_hours` (default 24h) to `DiscoveryConfig`, matching the value already documented in the crawler-improvements spec's example config.
- Adds a `discovery_run` SQLite table to `ManifestStore` (`record_discovery_run` / `get_last_discovery_run`) tracking each site's last completed discovery run — just a `completed_at` timestamp and `complete` flag, not a full run-history log (that's a larger change, deferred per #77's discussion).
- `DiscoveryRunner.run()` checks this before fetching: if a sitemap-source site's last discovery run completed within `cache_ttl_hours`, it skips the robots.txt and sitemap fetch entirely and rebuilds the run summary (`discovered`/`eligible`/`excluded_by_reason`) from the manifest's existing records instead. `DiscoveryRunSummary` gains a `cached: bool` field so callers/logs can tell.
- Every sitemap-source run (cached or not) records its completion, so a run that failed (e.g. robots.txt unreachable) is stored as incomplete and never served from cache.
- `cache_ttl_hours: 0` disables caching outright — always re-fetches, matching the issue's stated escape hatch.
- `discover`'s CLI output notes `(cache hit; no HTTP requests made)` when the summary came from cache.
- Gap-crawl discovery is untouched — caching only applies to `discovery.source == "sitemap"`.

Closes #76

## Test plan

- [x] `uv run pytest` — full crawler suite passes (120 tests)
- [x] New tests cover: cache hit skips HTTP calls and rebuilds discovered/eligible/excluded_by_reason from the manifest; cache miss after TTL elapse re-fetches; `cache_ttl_hours=0` always re-fetches; a successful run records `discovery_run`; an incomplete run (robots unreachable) is recorded incomplete and not served from cache; `ManifestStore.record_discovery_run`/`get_last_discovery_run` round-trip, overwrite-on-rerun, and per-site isolation; CLI prints the cache-hit note
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy tapio_crawler` / `uv run pyrefly check tapio_crawler` — clean
- [x] pre-commit hooks passed on the commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added caching for completed sitemap discovery runs to reduce repeat network requests.
  * Added a configurable cache duration, defaulting to 24 hours; setting it to zero disables caching.
  * Discovery status now indicates when results were served from cache.
  * Cached results are refreshed when sitemap URLs, scope settings, or the base URL changes.

* **Bug Fixes**
  * Incomplete, failed, or inaccessible-robots runs are no longer reused as cached results.
  * Cached result counts now accurately reflect stored discovery records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->